### PR TITLE
Table headers-id rules refactor

### DIFF
--- a/_drafts/SC1-3-1-tables-headers-id-correct.md
+++ b/_drafts/SC1-3-1-tables-headers-id-correct.md
@@ -1,7 +1,7 @@
 ---
-rule_id: SC1-3-1-tables-headers-id
-name: Tables headers-id associations
-test_mode: automatic
+rule_id: SC1-3-1-tables-headers-id-correct
+name: Tables headers-id associations correct
+test_mode: semi-automatic
 environment:  DOM Structure
 
 success_criterion:
@@ -13,7 +13,7 @@ authors:
 
 ## Description
 
-This rule checks that data table headers-id associations are used correctly.
+This rule checks that data table headers-id associations reference correct targets in the correct order.
 
 ## Background
 
@@ -29,7 +29,9 @@ This rule checks that data table headers-id associations are used correctly.
 
 ### Selector
 
-Select all elements that match the following CSS selector:
+Loop outward from most deeply nested table.
+
+For each un-marked table, select all elements that match the following CSS selector:
 
     table:not([role=presentation]) th[headers],
     table:not([role=presentation]) td[headers],
@@ -38,48 +40,92 @@ Select all elements that match the following CSS selector:
 
 ### Step 1
 
-Test method: [automatic][AUTO]
+Mark table complete.
 
 For each value in each cell `headers` attribute,
 
-check that the value references a cell `id` attribute value within the same table,
+find the the 'td' or 'th' referenced,
 
-if yes, continue with [step 2](#step-2)
-
-else, return a fail:
-
-| Outcome  | Failed
-|----------|-----
-| ID       | SC1-3-1-tables-headers-id-fail1
-| Error    | A `headers` value in the table has no matching `id`.
-
-### Step 2
-
-Test method: [manual][MANUAL]
-
-Give the user the following question:
+give the user the following question:
 
 | Property             | Value
 |----------------------|---------
 | Presented item       | Highlight a table cell and the related "header" cell.
 | Question             | Is the cell appropriately categorized by or semantically related with the associated "header" cell?
-| Requires context     | Yes, an understanding of the data relationships in the table.
-| Requires interaction | No
+| Requires context     | Yes. An understanding of the data relationships in the table.
+| Requires interaction | Yes. Answering the question allows test to proceed to the next step or iteration.
 
-if yes:
+if yes, continue with [step 2](#step-2)
 
-| Outcome  | Passed
-|----------|-----
-| ID       | SC1-3-1-tables-headers-id-pass2
+else, return [step1-fail1](#step1-fail1).
 
-else, return a fail:
+### Step 2
 
-| Outcome  | Failed
-|----------|-----
-| ID       | SC1-3-1-tables-headers-id-fail2
-| Error    | Table cell's `id` references an incorrect `th` or `td` via 'headers' attribute.
+For each value in each cell `headers` attribute,
 
-...
+find the the 'td' or 'th' referenced,
 
-[AUTO]: ../pages/test-modes.html#automatic
-[MANUAL]: ../pages/test-modes.html#manual
+give the user the following question:
+
+| Property             | Value
+|----------------------|---------
+| Presented item       | Highlight a table cell and the related "header" cell. Display the sequence order of the header cell as a number value, as specified by the order in which the header's `id` appears within the cell's `headers` attribute.
+| Question             | Is the number of the related header consistent with the desired reading sequence?
+| Requires context     | Yes. An understanding of the data relationships in the table.
+| Requires interaction | Yes. Answering the question allows the test to proceed to the next iteration.
+
+if yes, return [step2-pass1](#step2-pass1)
+
+else, return [step2-fail1](#step2-fail1).
+
+## Outcome
+
+The resulting assertion is as follows,
+
+| Property | Value
+|----------|----------
+| type     | Assertion
+| test     | auto-wcag:SC1-3-1-tables-headers-id-correct
+| subject  | *the selected element*
+| mode     | semi-automatic
+| result   | One TestResult from below
+
+### step1-fail1
+
+| Property    | Value
+|-------------|----------
+| type        | TestResult
+| outcome     | Failed
+| description | Table cell references an incorrect `th` or `td` via the `headers` attribute.
+
+
+### step1-pass1
+
+| Property | Value
+|----------|----------
+| type     | TestResult
+| outcome  | Passed
+
+### step2-fail1
+
+| Property    | Value
+|-------------|----------
+| type        | TestResult
+| outcome     | Failed
+| description | Table cell references a `th` or `td` via the `headers` in an incorrect order.
+
+### step2-pass1
+
+| Property | Value
+|----------|----------
+| type     | TestResult
+| outcome  | Passed
+
+## Implementation Tests
+
+Implementation tests are available at: <placeholder>
+
+## Change log
+
+### Version 0.1
+- Initial draft of rule.

--- a/_drafts/SC1-3-1-tables-headers-id-correct.md
+++ b/_drafts/SC1-3-1-tables-headers-id-correct.md
@@ -24,6 +24,7 @@ This rule checks that data table headers-id associations reference correct targe
 ## Assumptions
 
 - Tables are [well-formed, according to the HTML5.1 specification.](https://www.w3.org/TR/html51/tabular-data.html#forming-a-table).
+- Tables pass [tables headers id valid](auto-wcag:SC1-3-1-tables-headers-id-valid).
 
 ## Test procedure
 
@@ -44,7 +45,7 @@ Mark table complete.
 
 For each value in each cell `headers` attribute,
 
-find the the 'td' or 'th' referenced,
+find the 'th' referenced,
 
 give the user the following question:
 
@@ -52,8 +53,8 @@ give the user the following question:
 |----------------------|---------
 | Presented item       | Highlight a table cell and the related "header" cell.
 | Question             | Is the cell appropriately categorized by or semantically related with the associated "header" cell?
-| Requires context     | Yes. An understanding of the data relationships in the table.
-| Requires interaction | Yes. Answering the question allows test to proceed to the next step or iteration.
+| Requires context     | Yes.
+| Requires interaction | Yes.
 
 if yes, continue with [step 2](#step-2)
 
@@ -63,16 +64,16 @@ else, return [step1-fail1](#step1-fail1).
 
 For each value in each cell `headers` attribute,
 
-find the the 'td' or 'th' referenced,
+find the 'th' referenced,
 
 give the user the following question:
 
 | Property             | Value
 |----------------------|---------
-| Presented item       | Highlight a table cell and the related "header" cell. Display the sequence order of the header cell as a number value, as specified by the order in which the header's `id` appears within the cell's `headers` attribute.
+| Presented item       | Highlight a table cell and the related header cell. Display the sequence order of the header cell as a number value, as specified by the order in which the header's `id` appears within the cell's `headers` attribute.
 | Question             | Is the number of the related header consistent with the desired reading sequence?
-| Requires context     | Yes. An understanding of the data relationships in the table.
-| Requires interaction | Yes. Answering the question allows the test to proceed to the next iteration.
+| Requires context     | Yes.
+| Requires interaction | Yes.
 
 if yes, return [step2-pass1](#step2-pass1)
 
@@ -96,7 +97,7 @@ The resulting assertion is as follows,
 |-------------|----------
 | type        | TestResult
 | outcome     | Failed
-| description | Table cell references an incorrect `th` or `td` via the `headers` attribute.
+| description | Table cell references an incorrect `th` via the `headers` attribute.
 
 
 ### step1-pass1
@@ -112,7 +113,7 @@ The resulting assertion is as follows,
 |-------------|----------
 | type        | TestResult
 | outcome     | Failed
-| description | Table cell references a `th` or `td` via the `headers` in an incorrect order.
+| description | Table cell references a `th` via the `headers` in an incorrect order.
 
 ### step2-pass1
 
@@ -126,6 +127,11 @@ The resulting assertion is as follows,
 Implementation tests are available at: <placeholder>
 
 ## Change log
+
+### Version 0.2
+- Removed explanations from Requires context and Requires interaction rows in Step 1 and Step 2 questions.
+- Rule now conforms to HTML 5.1 spec: `headers` can only reference a `th`.
+- Added recommended dependency on [tables headers id valid](auto-wcag:SC1-3-1-tables-headers-id-valid).
 
 ### Version 0.1
 - Initial draft of rule.

--- a/_drafts/SC1-3-1-tables-headers-id-correct.md
+++ b/_drafts/SC1-3-1-tables-headers-id-correct.md
@@ -1,7 +1,7 @@
 ---
 rule_id: SC1-3-1-tables-headers-id
 name: Tables headers-id associations
-test_mode: semi-automatic
+test_mode: automatic
 environment:  DOM Structure
 
 success_criterion:
@@ -20,7 +20,6 @@ This rule checks that data table headers-id associations are used correctly.
 - [F90: Failure of Success Criterion 1.3.1 for incorrectly associating table headers and content via the headers and id attributes](https://www.w3.org/TR/WCAG20-TECHS/F90.html)
 - [H43: Using id and headers attributes to associate data cells with header cells in data tables](https://www.w3.org/TR/WCAG20-TECHS/H43.html)
 - [F46: Failure of Success Criterion 1.3.1 due to using th elements, caption elements, or non-empty summary attributes in layout tables](https://www.w3.org/TR/WCAG20-TECHS/F46.html)
-- Auto-WCAG SC1-3-1-tables-layout
 
 ## Assumptions
 

--- a/_drafts/SC1-3-1-tables-headers-id-valid.md
+++ b/_drafts/SC1-3-1-tables-headers-id-valid.md
@@ -1,0 +1,87 @@
+---
+rule_id: SC1-3-1-tables-headers-id
+name: Tables headers-id associations
+test_mode: automatic
+environment:  DOM Structure
+
+success_criterion:
+- 1.3.1 # Info and relationships (level A)
+
+authors:
+- Ken Petri
+---
+
+## Description
+
+This rule checks that data table `headers` attributes have values that reference `td` or `th` elements in the same table.
+
+## Background
+
+- [F90: Failure of Success Criterion 1.3.1 for incorrectly associating table headers and content via the headers and id attributes](https://www.w3.org/TR/WCAG20-TECHS/F90.html)
+- [H43: Using id and headers attributes to associate data cells with header cells in data tables](https://www.w3.org/TR/WCAG20-TECHS/H43.html)
+- [F46: Failure of Success Criterion 1.3.1 due to using th elements, caption elements, or non-empty summary attributes in layout tables](https://www.w3.org/TR/WCAG20-TECHS/F46.html)
+
+## Assumptions
+
+- Tables are [well-formed, according to the HTML5.1 specification.](https://www.w3.org/TR/html51/tabular-data.html#forming-a-table).
+
+## Test procedure
+
+### Selector
+
+Loop outward from most deeply nested table.
+
+For each un-marked table, select all elements that match the following CSS selector:
+
+    table:not([role=presentation]) th[headers],
+    table:not([role=presentation]) td[headers],
+    table:not([role=none]) th[headers],
+    table:not([role=none]) td[headers]
+
+### Step 1
+
+Mark table completed.
+
+For each value in each cell `headers` attribute,
+
+check that the value references a cell `id` attribute value within the selected table,
+
+if yes, return [step1-pass](#step1-pass)
+
+else, return [step1-fail](#step1-fail).
+
+| Outcome  | Failed
+|----------|-----
+| ID       | SC1-3-1-tables-headers-id-fail1
+| Error    | A `headers` value in the table has no matching `id`.
+
+### Step 2
+
+Test method: [manual][MANUAL]
+
+Give the user the following question:
+
+| Property             | Value
+|----------------------|---------
+| Presented item       | Highlight a table cell and the related "header" cell.
+| Question             | Is the cell appropriately categorized by or semantically related with the associated "header" cell?
+| Requires context     | Yes, an understanding of the data relationships in the table.
+| Requires interaction | No
+
+if yes:
+
+| Outcome  | Passed
+|----------|-----
+| ID       | SC1-3-1-tables-headers-id-pass2
+
+else, return a fail:
+
+| Outcome  | Failed
+|----------|-----
+| ID       | SC1-3-1-tables-headers-id-fail2
+| Error    | Table cell's `id` references an incorrect `th` or `td` via 'headers' attribute.
+
+...
+
+[AUTO]: ../pages/test-modes.html#automatic
+[MANUAL]: ../pages/test-modes.html#manual

--- a/_drafts/SC1-3-1-tables-headers-id-valid.md
+++ b/_drafts/SC1-3-1-tables-headers-id-valid.md
@@ -44,7 +44,7 @@ Mark table completed.
 
 For each value in each cell `headers` attribute,
 
-check that the value references a cell `id` attribute value within the currently selected table,
+check that the value references an `id` attribute value of a `th` within the currently selected table,
 
 if yes, return [step1-pass1](#step1-pass1)
 
@@ -68,7 +68,7 @@ The resulting assertion is as follows,
 |-------------|----------
 | type        | TestResult
 | outcome     | Failed
-| description | Table cell references an invalid `th` or `td` via the `headers` attribute.
+| description | Table cell's `headers` attribute contains an `id` that does not correspond to a `th` in the same table.
 
 ### step1-pass1
 
@@ -82,6 +82,9 @@ The resulting assertion is as follows,
 Implementation tests are available at: <placeholder>
 
 ## Change log
+
+### Version 0.3
+- Rule now conforms to HTML 5.1 spec: `headers` can only reference a `th`.
 
 ### Version 0.2
 - Refactored into an automatic rule (this one) and a semi-automatic rule, [tables headers id correct](auto-wcag:SC1-3-1-tables-headers-id-correct).

--- a/_drafts/SC1-3-1-tables-headers-id-valid.md
+++ b/_drafts/SC1-3-1-tables-headers-id-valid.md
@@ -1,6 +1,6 @@
 ---
-rule_id: SC1-3-1-tables-headers-id
-name: Tables headers-id associations
+rule_id: SC1-3-1-tables-headers-id-valid
+name: Tables headers-id associations valid
 test_mode: automatic
 environment:  DOM Structure
 
@@ -44,44 +44,49 @@ Mark table completed.
 
 For each value in each cell `headers` attribute,
 
-check that the value references a cell `id` attribute value within the selected table,
+check that the value references a cell `id` attribute value within the currently selected table,
 
-if yes, return [step1-pass](#step1-pass)
+if yes, return [step1-pass1](#step1-pass1)
 
-else, return [step1-fail](#step1-fail).
+else, return [step1-fail1](#step1-fail1).
 
-| Outcome  | Failed
-|----------|-----
-| ID       | SC1-3-1-tables-headers-id-fail1
-| Error    | A `headers` value in the table has no matching `id`.
+## Outcome
 
-### Step 2
+The resulting assertion is as follows,
 
-Test method: [manual][MANUAL]
+| Property | Value
+|----------|----------
+| type     | Assertion
+| test     | auto-wcag:SC1-3-1-tables-headers-id-valid
+| subject  | *the selected element*
+| mode     | automatic
+| result   | One TestResult from below
 
-Give the user the following question:
+### step1-fail1
 
-| Property             | Value
-|----------------------|---------
-| Presented item       | Highlight a table cell and the related "header" cell.
-| Question             | Is the cell appropriately categorized by or semantically related with the associated "header" cell?
-| Requires context     | Yes, an understanding of the data relationships in the table.
-| Requires interaction | No
+| Property    | Value
+|-------------|----------
+| type        | TestResult
+| outcome     | Failed
+| description | Table cell references an invalid `th` or `td` via the `headers` attribute.
 
-if yes:
+### step1-pass1
 
-| Outcome  | Passed
-|----------|-----
-| ID       | SC1-3-1-tables-headers-id-pass2
+| Property | Value
+|----------|----------
+| type     | TestResult
+| outcome  | Passed
 
-else, return a fail:
+## Implementation Tests
 
-| Outcome  | Failed
-|----------|-----
-| ID       | SC1-3-1-tables-headers-id-fail2
-| Error    | Table cell's `id` references an incorrect `th` or `td` via 'headers' attribute.
+Implementation tests are available at: <placeholder>
 
-...
+## Change log
 
-[AUTO]: ../pages/test-modes.html#automatic
-[MANUAL]: ../pages/test-modes.html#manual
+### Version 0.2
+- Refactored into an automatic rule (this one) and a semi-automatic rule, [tables headers id correct](auto-wcag:SC1-3-1-tables-headers-id-correct).
+- Selector corrected.
+- Ensures selector tests only a single table at a time (for nested tables).
+- Conforms to rule template.
+
+

--- a/_drafts/SC1-3-1-tables-headers-id.md
+++ b/_drafts/SC1-3-1-tables-headers-id.md
@@ -1,0 +1,86 @@
+---
+rule_id: SC1-3-1-tables-headers-id
+name: Tables headers-id associations
+test_mode: semi-automatic
+environment:  DOM Structure
+
+success_criterion:
+- 1.3.1 # Info and relationships (level A)
+
+authors:
+- Ken Petri
+---
+
+## Description
+
+This rule checks that data table headers-id associations are used correctly.
+
+## Background
+
+- [F90: Failure of Success Criterion 1.3.1 for incorrectly associating table headers and content via the headers and id attributes](https://www.w3.org/TR/WCAG20-TECHS/F90.html)
+- [H43: Using id and headers attributes to associate data cells with header cells in data tables](https://www.w3.org/TR/WCAG20-TECHS/H43.html)
+- [F46: Failure of Success Criterion 1.3.1 due to using th elements, caption elements, or non-empty summary attributes in layout tables](https://www.w3.org/TR/WCAG20-TECHS/F46.html)
+- Auto-WCAG SC1-3-1-tables-layout
+
+## Assumptions
+
+- Tables are [well-formed, according to the HTML5.1 specification.](https://www.w3.org/TR/html51/tabular-data.html#forming-a-table).
+
+## Test procedure
+
+### Selector
+
+Select all elements that match the following CSS selector:
+
+    table:not([role=presentation]) th[headers],
+    table:not([role=presentation]) td[headers],
+    table:not([role=none]) th[headers],
+    table:not([role=none]) td[headers]
+
+### Step 1
+
+Test method: [automatic][AUTO]
+
+For each value in each cell `headers` attribute,
+
+check that the value references a cell `id` attribute value within the same table,
+
+if yes, continue with [step 2](#step-2)
+
+else, return a fail:
+
+| Outcome  | Fail
+|----------|-----
+| ID       | SC1-3-1-tables-headers-id-fail1
+| Error    | A `headers` value in the table has no matching `id`.
+
+### Step 2
+
+Test method: [manual][MANUAL]
+
+Give the user the following question:
+
+| Property             | Value
+|----------------------|---------
+| Presented item       | Highlight a table cell and the related "header" cell.
+| Question             | Is the cell appropriately categorized by or semantically related with the associated "header" cell?
+| Requires context     | Yes, an understanding of the data relationships in the table.
+| Requires interaction | No
+
+if yes:
+
+| Outcome  | Pass
+|----------|-----
+| ID       | SC1-3-1-tables-headers-id-pass2
+
+else, return a fail:
+
+| Outcome  | Fail
+|----------|-----
+| ID       | SC1-3-1-tables-headers-id-fail2
+| Error    | Table cell's `id` references an incorrect `th` or `td` via 'headers' attribute.
+
+...
+
+[AUTO]: ../pages/test-modes.html#automatic
+[MANUAL]: ../pages/test-modes.html#manual

--- a/_drafts/SC1-3-1-tables-headers-id.md
+++ b/_drafts/SC1-3-1-tables-headers-id.md
@@ -49,7 +49,7 @@ if yes, continue with [step 2](#step-2)
 
 else, return a fail:
 
-| Outcome  | Fail
+| Outcome  | Failed
 |----------|-----
 | ID       | SC1-3-1-tables-headers-id-fail1
 | Error    | A `headers` value in the table has no matching `id`.
@@ -69,13 +69,13 @@ Give the user the following question:
 
 if yes:
 
-| Outcome  | Pass
+| Outcome  | Passed
 |----------|-----
 | ID       | SC1-3-1-tables-headers-id-pass2
 
 else, return a fail:
 
-| Outcome  | Fail
+| Outcome  | Failed
 |----------|-----
 | ID       | SC1-3-1-tables-headers-id-fail2
 | Error    | Table cell's `id` references an incorrect `th` or `td` via 'headers' attribute.


### PR DESCRIPTION
Original draft rule was refactored into two rules, one fully automatic and the other semi-automatic. Rules were made to conform with the rule template.