### PR TITLE
Added Undetermined outcome before user questions

### DIFF
--- a/_rules/SC1-1-1-aria-describedby.md
+++ b/_rules/SC1-1-1-aria-describedby.md
@@ -60,9 +60,9 @@ else, return [step2-fail](#step2-fail)
 
 Concatenate the results of [Text Alternative Computation][TXTALT] Algorithm run on the element itself and assign it to variable T1 and on all elements referenced by the `aria-describedby` attribute and assign it to variable T2.
 
-**User Input Question:**
-
 If the user in not available, return [step3-cannottell](#step3-cannottell)
+
+**User Input Question:**
 
 | Property     | Value
 |--------------|---------

--- a/_rules/SC1-1-1-aria-describedby.md
+++ b/_rules/SC1-1-1-aria-describedby.md
@@ -60,8 +60,6 @@ else, return [step2-fail](#step2-fail)
 
 Concatenate the results of [Text Alternative Computation][TXTALT] Algorithm run on the element itself and assign it to variable T1 and on all elements referenced by the `aria-describedby` attribute and assign it to variable T2.
 
-If the user in not available, return [step3-cannottell](#step3-cannottell)
-
 **User Input Question:**
 
 | Property     | Value
@@ -105,14 +103,6 @@ The resulting assertion is as follows,
 | type        | TestResult
 | outcome     | Failed
 | description | None of the elements referenced by aria-describedby exists.
-
-### step3-cannottell
-
-| Property    | Value
-|-------------|----------
-| type        | TestResult
-| outcome     | Cannot tell
-| description | It is not possible to determine if the long description provided using aria-describedby is sufficiently descriptive.
 
 ### step3-pass
 

--- a/_rules/SC1-1-1-aria-describedby.md
+++ b/_rules/SC1-1-1-aria-describedby.md
@@ -60,7 +60,7 @@ else, return [step2-fail](#step2-fail)
 
 Concatenate the results of [Text Alternative Computation][TXTALT] Algorithm run on the element itself and assign it to variable T1 and on all elements referenced by the `aria-describedby` attribute and assign it to variable T2.
 
-If the user in not available, return [step3-cannottell](#step3-cannottell)
+If the user in not available, return [step3-undetermined](#step3-undetermined)
 
 **User Input Question:**
 
@@ -106,12 +106,12 @@ The resulting assertion is as follows,
 | outcome     | Failed
 | description | None of the elements referenced by aria-describedby exists.
 
-### step3-cannottell
+### step3-undetermined
 
 | Property    | Value
 |-------------|----------
 | type        | TestResult
-| outcome     | Cannot tell
+| outcome     | Undetermined
 | description | It is not possible to determine if the long description provided using aria-describedby is sufficiently descriptive.
 
 ### step3-pass

--- a/_rules/SC1-1-1-aria-describedby.md
+++ b/_rules/SC1-1-1-aria-describedby.md
@@ -60,6 +60,8 @@ else, return [step2-fail](#step2-fail)
 
 Concatenate the results of [Text Alternative Computation][TXTALT] Algorithm run on the element itself and assign it to variable T1 and on all elements referenced by the `aria-describedby` attribute and assign it to variable T2.
 
+If the user in not available, return [step3-cannottell](#step3-cannottell)
+
 **User Input Question:**
 
 | Property     | Value
@@ -103,6 +105,14 @@ The resulting assertion is as follows,
 | type        | TestResult
 | outcome     | Failed
 | description | None of the elements referenced by aria-describedby exists.
+
+### step3-cannottell
+
+| Property    | Value
+|-------------|----------
+| type        | TestResult
+| outcome     | Cannot tell
+| description | It is not possible to determine if the long description provided using aria-describedby is sufficiently descriptive.
 
 ### step3-pass
 

--- a/_rules/SC1-1-1-aria-describedby.md
+++ b/_rules/SC1-1-1-aria-describedby.md
@@ -62,6 +62,8 @@ Concatenate the results of [Text Alternative Computation][TXTALT] Algorithm run 
 
 **User Input Question:**
 
+If the user in not available, return [step3-cannottell](#step3-cannottell)
+
 | Property     | Value
 |--------------|---------
 | highlight    | Element with T1 and T2
@@ -103,6 +105,14 @@ The resulting assertion is as follows,
 | type        | TestResult
 | outcome     | Failed
 | description | None of the elements referenced by aria-describedby exists.
+
+### step3-cannottell
+
+| Property    | Value
+|-------------|----------
+| type        | TestResult
+| outcome     | Cannot tell
+| description | It is not possible to determine if the long description provided using aria-describedby is sufficiently descriptive.
 
 ### step3-pass
 

--- a/_rules/SC1-1-1-css-image.md
+++ b/_rules/SC1-1-1-css-image.md
@@ -61,7 +61,7 @@ Check if the element is really used for solely decorative purposes.
 
 To prepare the element for presentation to the user, all calculated CSS properties of the element must be stored and its child elements must be removed.
 
-If the user in not available, return [step3-cannottell](#step3-cannottell)
+If the user in not available, return [step3-undetermined](#step3-undetermined)
 
 **User Input Question:**
 
@@ -84,7 +84,7 @@ Get any text from this ancestor, including shadow dom text and assign it to vari
 
 To prepare the element for presentation to the user, all calculated CSS properties of the element must be stored and its child elements must be removed.
 
-If the user in not available, return [step4-cannottell](#step4-cannottell)
+If the user in not available, return [step4-undetermined](#step4-undetermined)
 
 **User Input Question:**
 
@@ -130,12 +130,12 @@ The resulting assertion is as follows,
 | outcome     | Passed
 | description |
 
-### step3-cannottell
+### step3-undetermined
 
 | Property    | Value
 |-------------|----------
 | type        | TestResult
-| outcome     | Cannot tell
+| outcome     | Undetermined
 | description | It is not possible to determine if the image is solely for decorative purposes
 
 ### step3-pass
@@ -146,12 +146,12 @@ The resulting assertion is as follows,
 | outcome     | Passed
 | description |
 
-### step4-cannottell
+### step4-undetermined
 
 | Property    | Value
 |-------------|----------
 | type        | TestResult
-| outcome     | Cannot tell
+| outcome     | Undetermined
 | description | It is not possible to determine if a suitable description is provided in text nearby
 
 ### step4-pass

--- a/_rules/SC1-1-1-css-image.md
+++ b/_rules/SC1-1-1-css-image.md
@@ -61,6 +61,8 @@ Check if the element is really used for solely decorative purposes.
 
 To prepare the element for presentation to the user, all calculated CSS properties of the element must be stored and its child elements must be removed.
 
+If the user in not available, return [step3-cannottell](#step3-cannottell)
+
 **User Input Question:**
 
 | Property     | Value
@@ -81,6 +83,8 @@ Get the current elements nearest ancestor with its display style set to block.
 Get any text from this ancestor, including shadow dom text and assign it to variable T1.
 
 To prepare the element for presentation to the user, all calculated CSS properties of the element must be stored and its child elements must be removed.
+
+If the user in not available, return [step4-cannottell](#step4-cannottell)
 
 **User Input Question:**
 
@@ -126,6 +130,14 @@ The resulting assertion is as follows,
 | outcome     | Passed
 | description |
 
+### step3-cannottell
+
+| Property    | Value
+|-------------|----------
+| type        | TestResult
+| outcome     | Cannot tell
+| description | It is not possible to determine if the image is solely for decorative purposes
+
 ### step3-pass
 
 | Property    | Value
@@ -133,6 +145,14 @@ The resulting assertion is as follows,
 | type        | TestResult
 | outcome     | Passed
 | description |
+
+### step4-cannottell
+
+| Property    | Value
+|-------------|----------
+| type        | TestResult
+| outcome     | Cannot tell
+| description | It is not possible to determine if a suitable description is provided in text nearby
 
 ### step4-pass
 

--- a/_rules/SC1-1-1-longdesc.md
+++ b/_rules/SC1-1-1-longdesc.md
@@ -56,7 +56,7 @@ else, return [step2-fail](#step2-fail)
 
 Concatenate the results of [Text Alternative Computation][TXTALT] Algorithm run on the element and assign it to variable T1.
 
-If the user in not available, return [step3-cannottell](#step3-cannottell)
+If the user in not available, return [step3-undetermined](#step3-undetermined)
 
 **User Input Question:**
 
@@ -103,12 +103,12 @@ The resulting assertion is as follows,
 | description | LONGDESC reference does not exist
 | info        | The URL given as LONGDESC value was not retrievable.
 
-### step3-cannottell
+### step3-undetermined
 
 | Property    | Value
 |-------------|----------
 | type        | TestResult
-| outcome     | Cannot tell
+| outcome     | Undetermined
 | description | It is not possible to determine if the long description provided is sufficiently descriptive.
 
 ###  step3-pass

--- a/_rules/SC1-1-1-longdesc.md
+++ b/_rules/SC1-1-1-longdesc.md
@@ -56,6 +56,8 @@ else, return [step2-fail](#step2-fail)
 
 Concatenate the results of [Text Alternative Computation][TXTALT] Algorithm run on the element and assign it to variable T1.
 
+If the user in not available, return [step3-cannottell](#step3-cannottell)
+
 **User Input Question:**
 
 | Property     | Value
@@ -100,6 +102,14 @@ The resulting assertion is as follows,
 | outcome     | Failed
 | description | LONGDESC reference does not exist
 | info        | The URL given as LONGDESC value was not retrievable.
+
+### step3-cannottell
+
+| Property    | Value
+|-------------|----------
+| type        | TestResult
+| outcome     | Cannot tell
+| description | It is not possible to determine if the long description provided is sufficiently descriptive.
 
 ###  step3-pass
 

--- a/_rules/SC1-1-1-text-alternative.md
+++ b/_rules/SC1-1-1-text-alternative.md
@@ -103,7 +103,7 @@ Concatenate the results of [Text Alternative Computation][TXTALT] Algorithm run 
 
 All items of the group should be removed from the set of selector-matches after this step.
 
-If the user in not available, return [step6-cannottell](#step6-cannottell)
+If the user in not available, return [step6-undetermined](#step6-undetermined)
 
 **User Input Question:**
 
@@ -127,7 +127,7 @@ Concatenate the results of [Text Alternative Computation][TXTALT] Algorithm run 
 
 All items of the group should be removed from the set of selector-matches after this step.
 
-If the user in not available, return [step7-cannottell](#step7-cannottell)
+If the user in not available, return [step7-undetermined](#step7-undetermined)
 
 **User Input Question:**
 
@@ -189,7 +189,7 @@ else Continue with [Step 12: ask if decorative (no text alternative)](#step-12-a
 
 ### Step 12: ask if decorative (no text alternative)
 
-If the user in not available, return [step12-cannottell](#step12-cannottell)
+If the user in not available, return [step12-undetermined](#step12-undetermined)
 
 **User Input Question:**
 
@@ -271,7 +271,7 @@ else continue with [[#Step 18: ask if sufficiently described by adjacent text]]
 
 ### Step 18: ask if sufficiently described by adjacent text
 
-If the user in not available, return [step18-cannottell](#step18-cannottell)
+If the user in not available, return [step18-undetermined](#step18-undetermined)
 
 **User Input Question:**
 
@@ -314,12 +314,12 @@ The resulting assertion is as follows,
 | outcome     | Failed
 | description | The element must provide one of the following attributes: `alt` , `aria-label`, `title` or a `aria-labelledby`.
 
-### step6-cannottell
+### step6-undetermined
 
 | Property    | Value
 |-------------|----------
 | type        | TestResult
-| outcome     | Cannot tell
+| outcome     | Undetermined
 | description | It is not possible to determine if the textual alternative is sufficiently descriptive.
 
 ### step6-pass
@@ -339,12 +339,12 @@ The resulting assertion is as follows,
 | description | Textual alternative T1 does not sufficiently describe the group of images.
 | info        | Suggestions for textual alternative: {collection of repair-answers}
 
-### step7-cannottell
+### step7-undetermined
 
 | Property    | Value
 |-------------|----------
 | type        | TestResult
-| outcome     | Cannot tell
+| outcome     | Undetermined
 | description | It is not possible to determine if the textual alternative is sufficiently descriptive.
 
 ### step7-pass
@@ -388,12 +388,12 @@ The resulting assertion is as follows,
 | outcome     | Passed
 | description |
 
-### step12-cannottell
+### step12-undetermined
 
 | Property    | Value
 |-------------|----------
 | type        | TestResult
-| outcome     | Cannot tell
+| outcome     | Undetermined
 | description | It is not possible to determine if this element is solely for decorative purposes.
 
 ### step12-pass
@@ -447,12 +447,12 @@ The resulting assertion is as follows,
 | outcome     | Passed
 | description |
 
-### step18-cannottell
+### step18-undetermined
 
 | Property    | Value
 |-------------|----------
 | type        | TestResult
-| outcome     | Cannot tell
+| outcome     | Undetermined
 | description | It is not possible to determine if the element is sufficiently described by adjacent text.
 
 ### step18-pass

--- a/_rules/SC1-1-1-text-alternative.md
+++ b/_rules/SC1-1-1-text-alternative.md
@@ -103,6 +103,8 @@ Concatenate the results of [Text Alternative Computation][TXTALT] Algorithm run 
 
 All items of the group should be removed from the set of selector-matches after this step.
 
+If the user in not available, return [step6-cannottell](#step6-cannottell)
+
 **User Input Question:**
 
 | Property     | Value
@@ -124,6 +126,8 @@ else return [step6-fail](#step6-fail)
 Concatenate the results of [Text Alternative Computation][TXTALT] Algorithm run on all images and assign it to variable T1.
 
 All items of the group should be removed from the set of selector-matches after this step.
+
+If the user in not available, return [step7-cannottell](#step7-cannottell)
 
 **User Input Question:**
 
@@ -184,6 +188,8 @@ if yes, return [step11-pass](#step11-pass)
 else Continue with [Step 12: ask if decorative (no text alternative)](#step-12-ask-if-decorative-no-text-alternative)
 
 ### Step 12: ask if decorative (no text alternative)
+
+If the user in not available, return [step12-cannottell](#step12-cannottell)
 
 **User Input Question:**
 
@@ -265,6 +271,8 @@ else continue with [[#Step 18: ask if sufficiently described by adjacent text]]
 
 ### Step 18: ask if sufficiently described by adjacent text
 
+If the user in not available, return [step18-cannottell](#step18-cannottell)
+
 **User Input Question:**
 
 | Property     | Value
@@ -306,13 +314,21 @@ The resulting assertion is as follows,
 | outcome     | Failed
 | description | The element must provide one of the following attributes: `alt` , `aria-label`, `title` or a `aria-labelledby`.
 
+### step6-cannottell
+
+| Property    | Value
+|-------------|----------
+| type        | TestResult
+| outcome     | Cannot tell
+| description | It is not possible to determine if the textual alternative is sufficiently descriptive.
+
 ### step6-pass
 
 | Property    | Value
 |-------------|----------
 | type        | TestResult
 | outcome     | Passed
-| description |
+| description | 
 
 ### step6-fail
 
@@ -322,6 +338,14 @@ The resulting assertion is as follows,
 | outcome     | Failed
 | description | Textual alternative T1 does not sufficiently describe the group of images.
 | info        | Suggestions for textual alternative: {collection of repair-answers}
+
+### step7-cannottell
+
+| Property    | Value
+|-------------|----------
+| type        | TestResult
+| outcome     | Cannot tell
+| description | It is not possible to determine if the textual alternative is sufficiently descriptive.
 
 ### step7-pass
 
@@ -363,6 +387,14 @@ The resulting assertion is as follows,
 | type        | TestResult
 | outcome     | Passed
 | description |
+
+### step12-cannottell
+
+| Property    | Value
+|-------------|----------
+| type        | TestResult
+| outcome     | Cannot tell
+| description | It is not possible to determine if this element is solely for decorative purposes.
 
 ### step12-pass
 
@@ -414,6 +446,14 @@ The resulting assertion is as follows,
 | type        | TestResult
 | outcome     | Passed
 | description |
+
+### step18-cannottell
+
+| Property    | Value
+|-------------|----------
+| type        | TestResult
+| outcome     | Cannot tell
+| description | It is not possible to determine if the element is sufficiently described by adjacent text.
 
 ### step18-pass
 

--- a/_rules/SC1-4-2-audio-control-audio.md
+++ b/_rules/SC1-4-2-audio-control-audio.md
@@ -76,6 +76,8 @@ Else, return [step4-pass](#step4-pass)
 
 Check if the video plays audio.
 
+If the user in not available, return [step5-cannottell](#step5-cannottell)
+
 **User Input Question:**
 
 | Property     | Value
@@ -94,6 +96,8 @@ Else, return [step5-pass](#step5-pass)
 ### Step 6
 
 Check if a mechanism to control the sound is provided as one of the first five links or buttons on the web page.
+
+If the user in not available, return [step6-cannottell](#step6-cannottell)
 
 **User Input Question:**
 
@@ -146,6 +150,14 @@ The resulting assertion is as follows,
 | outcome     | Passed
 | description |
 
+### step5-cannottell
+
+| Property    | Value
+|-------------|----------
+| type        | TestResult
+| outcome     | Cannot tell
+| description | It is not possible to determine if there is audio playing on the web page.
+
 ### step5-pass
 
 | Property    | Value
@@ -153,6 +165,14 @@ The resulting assertion is as follows,
 | type        | TestResult
 | outcome     | Passed
 | description |
+
+### step6-cannottell
+
+| Property    | Value
+|-------------|----------
+| type        | TestResult
+| outcome     | Cannot tell
+| description | It is not possible to determine if the web page provides a mechanism to control the sound as one of the first five links or buttons.
 
 ### step6-pass
 

--- a/_rules/SC1-4-2-audio-control-audio.md
+++ b/_rules/SC1-4-2-audio-control-audio.md
@@ -76,7 +76,7 @@ Else, return [step4-pass](#step4-pass)
 
 Check if the video plays audio.
 
-If the user in not available, return [step5-cannottell](#step5-cannottell)
+If the user in not available, return [step5-undetermined](#step5-undetermined)
 
 **User Input Question:**
 
@@ -97,7 +97,7 @@ Else, return [step5-pass](#step5-pass)
 
 Check if a mechanism to control the sound is provided as one of the first five links or buttons on the web page.
 
-If the user in not available, return [step6-cannottell](#step6-cannottell)
+If the user in not available, return [step6-undetermined](#step6-undetermined)
 
 **User Input Question:**
 
@@ -150,12 +150,12 @@ The resulting assertion is as follows,
 | outcome     | Passed
 | description |
 
-### step5-cannottell
+### step5-undetermined
 
 | Property    | Value
 |-------------|----------
 | type        | TestResult
-| outcome     | Cannot tell
+| outcome     | Undetermined
 | description | It is not possible to determine if there is audio playing on the web page.
 
 ### step5-pass
@@ -166,12 +166,12 @@ The resulting assertion is as follows,
 | outcome     | Passed
 | description |
 
-### step6-cannottell
+### step6-undetermined
 
 | Property    | Value
 |-------------|----------
 | type        | TestResult
-| outcome     | Cannot tell
+| outcome     | Undetermined
 | description | It is not possible to determine if the web page provides a mechanism to control the sound as one of the first five links or buttons.
 
 ### step6-pass

--- a/_rules/SC3-1-1-text.md
+++ b/_rules/SC3-1-1-text.md
@@ -68,9 +68,9 @@ If the user in not available, return [step2-cannottell](#step2-cannottell)
 | highlight    | 
 | question     | Is L1 the primary language of this page?
 | help         | "Primary language" means the language of the majority of the text on the page or the language of the interface (navigation menu etc.) of the page.
-| user_profile | 
-| context      | 
-| interaction  | 
+| user_profile | Understand the primary language 
+| context      | yes
+| interaction  | no
 
 *Note that language code L1 should be presented in human readable form, e.g. using the description from the [language subtag registry](http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).*
 

--- a/_rules/SC3-1-1-text.md
+++ b/_rules/SC3-1-1-text.md
@@ -59,11 +59,20 @@ Else continue with [Step 2](#step-2).
 
 Present the page to the user.
 
-Question: Is L1 the primary language of this page?
+If the user in not available, return [step2-cannottell](#step2-cannottell)
+
+**User Input Question:**
+
+| Property     | Value
+|--------------|---------
+| highlight    | 
+| question     | Is L1 the primary language of this page?
+| help         | "Primary language" means the language of the majority of the text on the page or the language of the interface (navigation menu etc.) of the page.
+| user_profile | 
+| context      | 
+| interaction  | 
 
 *Note that language code L1 should be presented in human readable form, e.g. using the description from the [language subtag registry](http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).*
-
-Help text: "Primary language" means the language of the majority of the text on the page or the language of the interface (navigation menu etc.) of the page.
 
 If yes, return [step2-pass](#step2-pass)
 
@@ -88,6 +97,14 @@ The resulting assertion is as follows,
 | type        | TestResult
 | outcome     | Passed
 | description |
+
+### step2-cannottell
+
+| Property    | Value
+|-------------|----------
+| type        | TestResult
+| outcome     | Cannot tell
+| description | It is not possible to determine if the primary language of the page is specified correctly.
 
 ### step2-pass
 

--- a/_rules/SC3-1-1-text.md
+++ b/_rules/SC3-1-1-text.md
@@ -59,7 +59,7 @@ Else continue with [Step 2](#step-2).
 
 Present the page to the user.
 
-If the user in not available, return [step2-cannottell](#step2-cannottell)
+If the user in not available, return [step2-undetermined](#step2-undetermined)
 
 **User Input Question:**
 
@@ -98,12 +98,12 @@ The resulting assertion is as follows,
 | outcome     | Passed
 | description |
 
-### step2-cannottell
+### step2-undetermined
 
 | Property    | Value
 |-------------|----------
 | type        | TestResult
-| outcome     | Cannot tell
+| outcome     | Undetermined
 | description | It is not possible to determine if the primary language of the page is specified correctly.
 
 ### step2-pass

--- a/_rules/SC3-1-2-text.md
+++ b/_rules/SC3-1-2-text.md
@@ -55,11 +55,20 @@ Else return [step1-fail](#step1-fail)
 
 Present the selected text to the user.
 
-Question: Is L1 the *only* language used in this text?
+If the user in not available, return [step2-undetermined](#step2-undetermined)
+
+**User Input Question:**
+
+| Property     | Value
+|--------------|---------
+| highlight    | 
+| question     | Is L1 the *only* language used in this text?
+| help         | If the text contains a phrase or sentence in another language, please answer "no". If there are only single words in another language and the rest of the text is in L1, please answer "yes".
+| user_profile | Understand the languages used in the text.
+| context      | yes
+| interaction  | no
 
 *Note that language codes should be presented in human readable form, e.g. using the description from the [language subtag registry](http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).*
-
-Help text: If the text contains a phrase or sentence in another language, please answer "no". If there are only single words in another language and the rest of the text is in L1, please answer "yes".
 
 If yes, return [step2-pass](#step2-pass)
 
@@ -92,6 +101,14 @@ The resulting assertion is as follows,
 | type        | TestResult
 | outcome     | Failed
 | description | The language of the text is not specified correctly.
+
+### step2-undetermined
+
+| Property    | Value
+|-------------|----------
+| type        | TestResult
+| outcome     | Undetermined
+| description | It is not possible to determine if the language of the text is specified correctly.
 
 ### step2-pass
 


### PR DESCRIPTION
To satisfy [ACT Rules Format 1.0](https://w3c.github.io/wcag-act/act-rules-format.html#output-outcome), I have added a "Undetermined" outcome value before user questions if the user is not available. In rules included in _rules folder.