### PR TITLE
fix: links in background were not anchors

### DIFF
--- a/_rules/SC2-4-2-page-has-title.md
+++ b/_rules/SC2-4-2-page-has-title.md
@@ -46,10 +46,10 @@ _There are no major accessibility support issues known for this rule._
 
 ## Background
 
-- https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-title.html
-- https://www.w3.org/WAI/WCAG20/quickref/?showtechniques=242#qr-navigation-mechanisms-title
-- https://www.w3.org/TR/WCAG20-TECHS/G88.html
-- https://www.w3.org/TR/WCAG20-TECHS/H25.html
+- [https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-title.html](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-title.html)
+- [https://www.w3.org/WAI/WCAG20/quickref/?showtechniques=242#qr-navigation-mechanisms-title](https://www.w3.org/WAI/WCAG20/quickref/?showtechniques=242#qr-navigation-mechanisms-title)
+- [https://www.w3.org/TR/WCAG20-TECHS/G88.html](https://www.w3.org/TR/WCAG20-TECHS/G88.html)
+- [https://www.w3.org/TR/WCAG20-TECHS/H25.html](https://www.w3.org/TR/WCAG20-TECHS/H25.html)
 - The WCAG 2.0 Techniques already contain examples and code snippets to illustrate which content passes or fails the test. Whenever possible auto-wcag refers to those. Another source for test cases is the W3C Before and After Demonstration.
 
 ## Test Cases

--- a/_rules/SC3-1-1-html-has-lang.md
+++ b/_rules/SC3-1-1-html-has-lang.md
@@ -37,11 +37,11 @@ There are known combinations of a popular operating system with browsers and ass
 
 ## Background
 
-- https://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140408/H57
-- https://www.ietf.org/rfc/bcp/bcp47.txt
-- https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang
-- https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xml:lang
-- https://www.w3.org/TR/WCAG20-TECHS/H57.html
+- [https://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140408/H57](https://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140408/H57)
+- [https://www.ietf.org/rfc/bcp/bcp47.txt](https://www.ietf.org/rfc/bcp/bcp47.txt)
+- [https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)
+- [https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xml:lang](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xml:lang)
+- [https://www.w3.org/TR/WCAG20-TECHS/H57.html](https://www.w3.org/TR/WCAG20-TECHS/H57.html)
 
 ## Test Cases
 

--- a/_rules/SC3-1-1-html-lang-valid.md
+++ b/_rules/SC3-1-1-html-lang-valid.md
@@ -37,11 +37,11 @@ While HTML5 specification indicates that `xml:lang` attribute takes priority ove
 
 ## Background
 
-- https://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140408/H57
-- https://www.ietf.org/rfc/bcp/bcp47.txt
-- https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang
-- https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xml:lang
-- https://www.w3.org/TR/WCAG20-TECHS/H57.html
+- [https://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140408/H57](https://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140408/H57)
+- [https://www.ietf.org/rfc/bcp/bcp47.txt](https://www.ietf.org/rfc/bcp/bcp47.txt)
+- [https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)
+- [https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xml:lang](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xml:lang)
+- [https://www.w3.org/TR/WCAG20-TECHS/H57.html](https://www.w3.org/TR/WCAG20-TECHS/H57.html)
 
 ## Test Cases
 

--- a/_rules/SC3-1-1-html-xml-lang-match.md
+++ b/_rules/SC3-1-1-html-xml-lang-match.md
@@ -37,10 +37,10 @@ Since most assistive technologies will consistently use `lang` over `xml:lang` w
 
 ## Background
 
-- https://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140408/H57
-- https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang
-- https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xml:lang
-- https://www.w3.org/TR/WCAG20-TECHS/H57.html
+- [https://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140408/H57](https://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140408/H57)
+- [https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)
+- [https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xml:lang](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xml:lang)
+- [https://www.w3.org/TR/WCAG20-TECHS/H57.html](https://www.w3.org/TR/WCAG20-TECHS/H57.html)
 
 ## Test Cases
 

--- a/_rules/SC3-1-2-lang-valid.md
+++ b/_rules/SC3-1-2-lang-valid.md
@@ -31,10 +31,10 @@ The `lang` and `xml:lang` attributes have a [valid language subtag](#valid-langu
 
 ## Background
 
-- https://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140408/H58
-- https://www.ietf.org/rfc/bcp/bcp47.txt
-- http://wiki.egovmon.no/wiki/SC3.1.2#Element_descendent-or-self::body.5B.40lang.5D_or_descendent-or-self::body.5B.40xml:lang.5D
-- https://www.w3.org/WAI/WCAG20/quickref/?showtechniques=312#qr-meaning-other-lang-id
+- [https://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140408/H58](https://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140408/H58)
+- [https://www.ietf.org/rfc/bcp/bcp47.txt](https://www.ietf.org/rfc/bcp/bcp47.txt)
+- [http://wiki.egovmon.no/wiki/SC3.1.2#Element_descendent-or-self::body.5B.40lang.5D_or_descendent-or-self::body.5B.40xml:lang.5D](http://wiki.egovmon.no/wiki/SC3.1.2#Element_descendent-or-self::body.5B.40lang.)
+- [https://www.w3.org/WAI/WCAG20/quickref/?showtechniques=312#qr-meaning-other-lang-id](https://www.w3.org/WAI/WCAG20/quickref/?showtechniques=312#qr-meaning-other-lang-id)
 
 ## Test Cases
 

--- a/_rules/SC4-1-1-unique-id.md
+++ b/_rules/SC4-1-1-unique-id.md
@@ -34,9 +34,9 @@ There are no major accessibility support issues known for this rule.
 
 ## Background
 
-- https://www.w3.org/WAI/WCAG20/quickref/?showtechniques=411#qr-ensure-compat-parses
-- https://www.w3.org/TR/WCAG20-TECHS/H93.html
-- https://www.w3.org/TR/WCAG20-TECHS/H94.html
+- [https://www.w3.org/WAI/WCAG20/quickref/?showtechniques=411#qr-ensure-compat-parses](https://www.w3.org/WAI/WCAG20/quickref/?showtechniques=411#qr-ensure-compat-parses)
+- [https://www.w3.org/TR/WCAG20-TECHS/H93.html](https://www.w3.org/TR/WCAG20-TECHS/H93.html)
+- [https://www.w3.org/TR/WCAG20-TECHS/H94.html](https://www.w3.org/TR/WCAG20-TECHS/H94.html)
 
 ## Test Cases
 


### PR DESCRIPTION
This is a maintenance PR, some of the published rules had links in background which were not anchors.