### PR TITLE
fix: no-frame option to not generate iframe for test cases

### DIFF
--- a/_plugins/frame_embed_generator.rb
+++ b/_plugins/frame_embed_generator.rb
@@ -12,7 +12,7 @@ module Jekyll
 
       KEY_EMBEDS_DIR =  JSON.parse(File.read('package.json'))['testcases-embeds-dir']
 			KEY_MATCH_CODE_TAG_BACKTICK = '```'
-			KEYWORD_NO_FRAME_IN_MARKDOWN = 'no-frame'
+			KEYWORD_NO_FRAME_IN_MARKDOWN = '(no-frame)'
       INCLUDE_FILE_TYPE = '.html'
       MESSAGES = {
         'ODD_TAG_COUNT' => 'Expects even pairs of' + KEY_MATCH_CODE_TAG_BACKTICK + ' and ' + KEY_MATCH_CODE_TAG_BACKTICK + '. Odd number of tags identified in page '
@@ -107,7 +107,7 @@ module Jekyll
 
 			def render_code_and_frame(snippet, url, no_frame)
 				code = "<div class='code-wrapper'> <figcaption>Code Snippet:</figcaption> {% highlight html %} #{snippet} {% endhighlight %} </div>"
-				frame = no_frame ? "<div class='frame-container'> </div>" : "<div class='frame-container'> <header><span>Example Output:</span> <a target='_blank' href='#{url}'>Open in a new tab/ window</a> </header> <iframe src='#{url}'></iframe> </div>"
+				frame = no_frame ? "" : "<div class='frame-container'> <header><span>Example Output:</span> <a target='_blank' href='#{url}'>Open in a new tab/ window</a> </header> <iframe src='#{url}'></iframe> </div>"
         out = "<div class='embed-wrapper'>"\
             "#{code}"\
             "#{frame}"\

--- a/assets/css/base.scss
+++ b/assets/css/base.scss
@@ -36,7 +36,6 @@ a {
 
 
 pre {
-	border-radius: 0;
 	padding: 0;
 	background-color: none;
 	border-color: $light-grey;
@@ -224,6 +223,7 @@ select {
 					}
 					iframe {
 						width: 100%;
+						border-radius: 4px;
 						border: 1px solid $light-grey;
 					}
 			}


### PR DESCRIPTION
This PR enables dis-allowing iframe generation for test cases code snippets by specifying `(no-frame)` in the markdown.

Eg: 
````
```html (no-frame)
<div id="my-div"> This is my first element</div>
```
````

Adding `(no-frame)` will not embed respective iframe in the resulting page.

Screenshot:
![image](https://user-images.githubusercontent.com/20978252/43841149-5decfc50-9b1a-11e8-9c6d-971eb1bed414.png)




Closes issue: https://github.com/auto-wcag/auto-wcag/issues/205

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Make sure you requesting to **pull a issue/feature/bugfix branch** (right side) to the master branch (left side).
- [ ] Make sure the pull request is prefixed with `Rule:` or `Algorithm:` or `Chore:` based on work involved.

# How to Review And Approve
- Go to the “files changed” tab, there you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “approve” and click “Submit review”.