### PR TITLE
Chore: Last modified time stamp on each rule

### DIFF
--- a/_layouts/rule.html
+++ b/_layouts/rule.html
@@ -11,8 +11,14 @@ layout: default
   {% assign status = "rule" %}
 {% endif %}
 
-{% if page.date %}
-  <p>Late updated: <time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time></p>
+{% if page.last-modified-timestamp %}
+  <p>Late updated: 
+		<time 
+			datetime="{{ page.last-modified-timestamp | date_to_xmlschema }}" 
+			itemprop="dateModified">
+			{{ page.last-modified-timestamp | date: "%b %-d, %Y" }}
+		</time>
+	</p>
 {% endif %}
 
 {% if page.authors %}

--- a/_plugins/last_modified_timestamp_hook.rb
+++ b/_plugins/last_modified_timestamp_hook.rb
@@ -1,0 +1,24 @@
+def append_last_modified_timestamp(item)
+	# get the current last modified time
+	timestamp = File.mtime(item.path)
+	# inject modification_time to front matter
+	item.data['last-modified-timestamp'] = timestamp
+end
+
+# Reference to all hooks
+# https://jekyllrb.com/docs/plugins/#hooks
+
+# Hook for all the documents
+Jekyll::Hooks.register :documents, :pre_render do |item|
+	append_last_modified_timestamp(item)
+end
+
+# Hook for all the pages
+Jekyll::Hooks.register :pages, :pre_render do |item|
+	append_last_modified_timestamp(item)
+end
+
+# Hook for all the posts
+Jekyll::Hooks.register :posts, :pre_render do |item|
+	append_last_modified_timestamp(item)
+end


### PR DESCRIPTION
This patch fixes the time stamp for `last modified date` on each rule. GH Pages Jekyll, does not provide this out of box (and page/ site.date is the last build timestamp), hence the custom plugin.

![image](https://user-images.githubusercontent.com/20978252/44467959-110a8f80-a61c-11e8-9add-0241b8a9da3f.png)


Closes issue:
- https://github.com/auto-wcag/auto-wcag/issues/221

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Make sure you requesting to **pull a issue/feature/bugfix branch** (right side) to the master branch (left side).
- [ ] Make sure the pull request is prefixed with `Rule:` or `Algorithm:` or `Chore:` based on work involved.

# How to Review And Approve
- Go to the “files changed” tab, there you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “approve” and click “Submit review”.