### PR TITLE
Documentation: "Contribute" page expanded

### DIFF
--- a/pages/contribute.md
+++ b/pages/contribute.md
@@ -3,13 +3,15 @@ layout: default
 title: Contribute to Auto-WCAG
 ---
 
-Auto-WCAG is a [W3C](https://www.w3.org/) [Community Group](https://www.w3.org/community/) open to anyone interested in accessibility or accessibility testing, manually or automated. 
+Auto-WCAG is a [W3C](https://www.w3.org/) [Community Group](https://www.w3.org/community/) open to anyone interested in accessibility testing, manually or automated. 
 
-We welcome contributions from anyone, and there are many ways to contribute, from Github issues and pull requests, to contribution to our monthly teleconferences.
+We welcome contributions from everyone, and there are many ways to contribute, from Github issues and pull requests, to contribution to our monthly teleconferences.
 
-You don't have to be a member of the Auto-WCAG Community Group to contribute by [giving feedback on rules](#give-feedback-on-rules) or [suggesting new rules](#suggest-new-rules).
+You don't have to be a member of the Auto-WCAG Community Group to contribute.
 
-If you want to get even more out of your involvement in our rule creation project, you can officially [join the Auto-WCAG Community Group](#join-the-Auto-WCAG-Community-Group) to get on the mailing list and participate in monthly teleconferences.
+If you want to get even more out of your involvement in our rule creation project, you can officially join the Auto-WCAG Community Group to get on the mailing list and participate in monthly teleconferences.
+
+<button name="button" onclick="#join-the-Auto-WCAG-Community-Group">Learn more about how to join the Auto-WCAG Community Group</button>
 
 ## Overview of how you can contribute
 
@@ -27,10 +29,12 @@ If you want to get even more out of your involvement in our rule creation projec
 
 ## Give feedback on rules
 
-Anyone can provide feedback on rules on our open [Auto-WCAG Github repository](https://github.com/auto-wcag/auto-wcag), so you don't even have to be a member of the Auto-WCAG Community Group to contribute in this way.
+Feedback on rules is encouraged on our open [Auto-WCAG Github repository](https://github.com/auto-wcag/auto-wcag), so you don't even have to be a member of the Auto-WCAG Community Group to contribute in this way.
+
+If you "watch" the repository, you will get notifications when changes are happening.
 
 ### Feedback for ideas and early drafts (Issues on Github) 
-Rules and Algorithms (shared terms across rules) that are Github Issues can be everything from just a title to a quite finished rule. The issues will be prefixed with either "Rule:" (or possibly "New Rule:") or "Algorithm". 
+Rules and Definitions (shared terms across rules) that are Github Issues can be everything from just a title to a quite finished rule. The issues will be prefixed with either "Rule:" (or possibly "New Rule:") or "Algorithm". 
 
 The top comment on an issue should hold the updated rule or algorithm, and underneath there will be a thread of comments and a history of actions related to the issue. 
 
@@ -40,23 +44,23 @@ Start giving feedback on issues:
 
 - See the [ideas and early drafts that might need input](https://github.com/auto-wcag/auto-wcag/issues) 
 
-- Use the [checklist for reviewers](#) (TBD) to guide your review
+- Use the [Definition of "Done"](../pages/design/definition-of-done.html) to guide your review
 - Learn more about [commenting on issues](#) (TBD)
 
 ### Feedback and reviews for draft rules (Pull Requests on Github)
 
-Pull requests holds rule drafts that are more finished than the ones in Issues. You can sign up as a reviewer and follow the rule through iterations. A rule needs three approvals, and if a rule has the label "Reviewer wanted", we need more people to sign up for reviewing it. But even if three people are already signed up, we can always use more eyes on it.
+Pull requests are rule drafts that are ready for peer reviews. You can sign up as a reviewer and follow the rule through iterations. A rule needs three approvals, and if a rule has the label "Reviewer wanted", we need more people to sign up for reviewing it. But even if three people are already signed up, we can always use more eyes on it.
 
 You can both add single comments to a pull request and do a full review. 
 
-**Only approve a rule** if you feel confident (to the best of your knowledge) that this rule is 100% ready to be a published ACT rule. Please also refer to the [checklist for reviewers](#) (TBD).
+**Only approve a rule** if you feel confident (to the best of your knowledge) that this rule is 100% ready to be a published ACT rule. Please also refer to the [Definition of "Done"](../pages/design/definition-of-done.html).
 
 If you for some reason are not so confident, you can always leave a comment for the things that you have an opinion about, without doing a full review.
 
 Start giving feedback and doing reviews for draft rules:
 
 - See the [draft rules, algorithms and more that need more reviewers](https://github.com/auto-wcag/auto-wcag/pulls?q=is%3Aopen+is%3Apr+label%3A%22reviewer+wanted%22)
-- Use the [checklist for reviewers](#) (TBD) to guide your review
+- Use the [Definition of "Done"](../pages/design/definition-of-done.html) to guide your review
 - Learn more about [reviewing and commenting on pull requests](#) (TBD)
 
 ### Feedback/corrections for published rules
@@ -119,3 +123,5 @@ The invitation and agenda for these meetings is sent out through the mailing lis
 1. To join the Auto-WCAG Community Group, you need a W3C Account. If you don’t already have one, [get a W3C account here](https://www.w3.org/accounts/request).
 2. Go to [Join the Auto-WCAG community group now!](https://www.w3.org/community/wp-login.php?redirect_to=%2Fcommunity%2Fauto-wcag%2Fjoin) and join the group.
 3. If you work for a W3C Member organization, you will need to request approval. This request will be sent to your organization’s representative in the W3C’s Advisory Committee.
+
+<button name="button" onclick="https://www.w3.org/community/wp-login.php?redirect_to=%2Fcommunity%2Fauto-wcag%2Fjoin">Join the Auto-WCAG Community Group</button>

--- a/pages/contribute.md
+++ b/pages/contribute.md
@@ -3,24 +3,119 @@ layout: default
 title: Contribute to Auto-WCAG
 ---
 
-Auto-WCAG is a group open to anyone interested in accessibility, accessibility testing or automated testing. We welcome contributions from anyone, either though Github issues and pull requests, or by contribution to our monthly teleconferences.
+Auto-WCAG is a [W3C](https://www.w3.org/) [Community Group](https://www.w3.org/community/) open to anyone interested in accessibility or accessibility testing, manually or automated. 
 
-## Leave your feedback on GitHub
+We welcome contributions from anyone, and there are many ways to contribute, from Github issues and pull requests, to contribution to our monthly teleconferences.
 
-Contributing is open to anyone. We welcome any pull requests for changes. We ask that you make changes to pull requests **only for drafts**. Before contributing new rules, we recommend you checked their validity with several experienced accessibility auditors first. This helps you identify potential stumbling blocks early in their design.
+You don't have to be a member of the Auto-WCAG Community Group to contribute by [giving feedback on rules](#give-feedback-on-rules) or [suggesting new rules](#suggest-new-rules).
 
-## Become a Auto-WCAG Member
+If you want to get even more out of your involvement in our rule creation project, you can officially [join the Auto-WCAG Community Group](#join-the-Auto-WCAG-Community-Group) to get on the mailing list and participate in monthly teleconferences.
 
-The best way to stay informed about the activities of Auto-WCAG is to become a member. By becoming a member you will be added to the mailing list, and you will receive all the latest updates.
+## Overview of how you can contribute
 
-1. To join the Auto-WCAG Community, you need a W3C Account.
-   If you don't already have one, you can get it here:
-   [https://www.w3.org/accounts/request].
-2. Go to **[Join the Auto-WcAG community group now!](https://www.w3.org/community/wp-login.php?redirect_to=%2Fcommunity%2Fauto-wcag%2Fjoin)** and join the group
-3. If you work for a W3C Member organization, you will need to request approval.
-   This request will be sent to your organization's representative in the W3C's
-   Advisory Committee.
+* [Give feedback on rules](#Give-feedback-on-rules)
+    * [Feedback for ideas and early drafts (Issues on Github)](#)
+    * [Feedback and reviews for draft rules (Pull Requests on Github)](#Feedback-for-ideas-and-early-drafts-(Issues-on-Github))
+    * [Feedback/corrections for published rules](#Feedback/corrections-for-published-rules)
+* [Suggest new rules](#Suggest-new-rules)
+    * [Submit an idea for discussion (Issue on Github)](#Submit-an-idea-for-discussion-(Issue-on-Github))
+    * [Submit a draft for a rule (Pull Request on Github)](#Submit-a-draft-for-a-rule-(Pull-Request-on-Github)
+* [Join the Auto-WCAG Community Group](#Join-the-Auto-WCAG-Community-Group)
+    * [Mailing list keeps you up to date](#Mailing-list-keeps-you-up-to-date)
+    * [Participate in our monthly calls](#Participate-in our-monthly-calls)
+    * [How to join the Auto-WCAG Community Group](#How-to-join-the-Auto-WCAG-Community-Group)
 
-## Participate in our monthly calls
+## Give feedback on rules
 
-Auto-WCAG has conference calls every month (usually) on the second Thursdays at 16:00 Central European Time. Participating in these calls is the easiest way to become an active contributor. The invitation and agenda for these meetings is sent out through the mailing list a few days in advance.
+Anyone can provide feedback on rules on our open [Auto-WCAG Github repository](https://github.com/auto-wcag/auto-wcag), so you don't even have to be a member of the Auto-WCAG Community Group to contribute in this way.
+
+### Feedback for ideas and early drafts (Issues on Github) 
+Rules and Algorithms (shared terms across rules) that are Github Issues can be everything from just a title to a quite finished rule. The issues will be prefixed with either "Rule:" (or possibly "New Rule:") or "Algorithm". 
+
+The top comment on an issue should hold the updated rule or algorithm, and underneath there will be a thread of comments and a history of actions related to the issue. 
+
+Please feel free to add your own comments to issues.
+
+Start giving feedback on issues:
+
+- See the [ideas and early drafts that might need input](https://github.com/auto-wcag/auto-wcag/issues) 
+
+- Use the [checklist for reviewers](#) (TBD) to guide your review
+- Learn more about [commenting on issues](#) (TBD)
+
+### Feedback and reviews for draft rules (Pull Requests on Github)
+
+Pull requests holds rule drafts that are more finished than the ones in Issues. You can sign up as a reviewer and follow the rule through iterations. A rule needs three approvals, and if a rule has the label "Reviewer wanted", we need more people to sign up for reviewing it. But even if three people are already signed up, we can always use more eyes on it.
+
+You can both add single comments to a pull request and do a full review. 
+
+**Only approve a rule** if you feel confident (to the best of your knowledge) that this rule is 100% ready to be a published ACT rule. Please also refer to the [checklist for reviewers](#) (TBD).
+
+If you for some reason are not so confident, you can always leave a comment for the things that you have an opinion about, without doing a full review.
+
+Start giving feedback and doing reviews for draft rules:
+
+- See the [draft rules, algorithms and more that need more reviewers](https://github.com/auto-wcag/auto-wcag/pulls?q=is%3Aopen+is%3Apr+label%3A%22reviewer+wanted%22)
+- Use the [checklist for reviewers](#) (TBD) to guide your review
+- Learn more about [reviewing and commenting on pull requests](#) (TBD)
+
+### Feedback/corrections for published rules
+We welcome any input for changes, also for already published rules. The published rules should be as precise as possible, limiting the number of potential false positives and false negatives. For this it is important to draw on as many tool and methodology implementations and expert opinions as possible. 
+
+Feedback and corrections for existing rules can target both on the sections of the rule itself (Applicability, Expectations, Accessibility Support, etc.) and the test cases, to e.g. expand the edge case coverage.
+
+You have several options for correcting existing rules: 
+
+- **Open a discussion in an Issue:** If you want to open a discussion, you can [open a new issue on Github](https://github.com/auto-wcag/auto-wcag/issues) repository to discuss the issue with the existing rule. Learn more about [creating issues](#) (TBD).
+- **Make the change yourself in a pull request:** If you know exactly what you want changed, you can do the change yourself as a [pull request on Github](https://github.com/auto-wcag/auto-wcag/pulls) and submit it for review. Learn more about [creating pull requests](#) (TBD).
+
+## Suggest new rules
+
+Anyone can suggest new rules on our open [Auto-WCAG Github repository](https://github.com/auto-wcag/auto-wcag), so you don't even have to be a member of the Auto-WCAG Community Group to contribute in this way.
+
+Whether you have a single great idea for an accessibility rule or you work for an organisation that wants to contribute a whole repository of rules, we welcome the contribution. 
+
+When you submit a rule, we expect you to be responsible for the rule the whole way through the review process, including adjusting the rule as you receive feedback from others. It will take some time and effort, but the learning experience in it is great.
+
+If you are not ready to carry a rule all the way through the process, you can partner up with someone else who wants to do it.
+
+Partnering up with someone outside of your own organisation for rule writing will sharpen the rule, which is why we often do that in the Auto-WCAG work.
+
+Depending on how polished your rule proposal is, you can either add your idea as an issue or a pull request. 
+
+### Submit an idea for discussion (Issue on Github)
+
+For rule contributors with less Github experience, it is often easiest to start the rule design in a [Github issue](https://github.com/auto-wcag/auto-wcag/issues). This allows for easy editing and discussions with others, while the rule is taking shape. 
+
+[Learn more about how we work in Github issues](#) (TBD).
+
+### Submit a draft for a rule (Pull Request on Github)
+
+If you have a ready rule draft, you can submit it as a [pull request](https://github.com/auto-wcag/auto-wcag/pulls) to go into the [Auto-WCAG review process](#) (TBD).
+
+Before contributing a new rule, we recommend you check its validity with several experienced accessibility auditors first. This helps you identify potential stumbling blocks early in the rule design. 
+
+If you want to use the experts in the Auto-WCAG Community Group for this, submit your rule suggestion as an Issue (see [Submit an idea for discussion](#) (TBD)). 
+
+[Learn more about the process for submitting rules as pull requests](#) (TBD)
+
+## Join the Auto-WCAG Community Group
+
+The best way to stay informed about the activities of Auto-WCAG is to become a member.
+
+### Mailing list keeps you up to date
+
+By becoming a member you will be added to the mailing list, and you will receive all the latest updates, meeting invites etc.
+
+### Participate in our monthly calls
+The Auto-WCAG Community Group has conference calls every month. It is (usually) on the second Thursday of the month at 16:00 to 17:30 Central European Time. [See the meeting time in your own timezone](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Auto-WCAG+Community+Group+meeting&iso=20180920T16&p1=259&ah=1&am=30).
+
+Participating in the Auto-WCAG conference calls is the easiest way to become an active contributor, get to know the other members of the Auto-WCAG Community Group, and learn from the shared pool of knowledge held by the accessibility experts in the group. 
+
+The invitation and agenda for these meetings is sent out through the mailing list a few days in advance. The dates for the next 3 meetings can also be found on the agenda.
+
+### How to join the Auto-WCAG Community Group
+
+1. To join the Auto-WCAG Community Group, you need a W3C Account. If you don’t already have one, [get a W3C account here](https://www.w3.org/accounts/request).
+2. Go to [Join the Auto-WCAG community group now!](https://www.w3.org/community/wp-login.php?redirect_to=%2Fcommunity%2Fauto-wcag%2Fjoin) and join the group.
+3. If you work for a W3C Member organization, you will need to request approval. This request will be sent to your organization’s representative in the W3C’s Advisory Committee.


### PR DESCRIPTION
Expanded all the possibilities for contributing on the "Contribute" page. 
Some links are still marked as (TBD), but I suggest we get this one out there anyway to get at least a step in the direction we want to go.

Closes issue: https://github.com/auto-wcag/auto-wcag/issues/238

## Guidance the the PR (pull request) creator

**When creating PR:**
- [X] Make sure you requesting to **pull a issue/feature/bugfix branch** (right side) to the master branch (left side).
- [X] Make sure the pull request is prefixed with `Rule:` or `Algorithm:` or `Chore:` based on work involved.

**After creating PR:**
- [X] Add yourself (and co-authors) as "Assignees" for PR
- [x] Add relevant project (e.g. "Q3 2018 Status") to PR
- [x] Close the issue that the PR resolves (and make sure the issue is referenced in the top of this comment)

# How to Review And Approve
- Go to the “files changed” tab, there you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “approve” and click “Submit review”.
