### PR TITLE
chore: front matter for rule (video has captions)

### DIFF
--- a/_rules/SC1-2-2-video-has-captions.md
+++ b/_rules/SC1-2-2-video-has-captions.md
@@ -9,8 +9,8 @@ success_criterion:
 test_aspects:
 - DOM Tree
 - CSS Styling
-- [Audio output]{#audio-output}
-- [Visual output]{#audio-output}
+- Audio output
+- Visual output
 
 authors:
 - Wilco Fiers


### PR DESCRIPTION
Fixes, yml front matter, to enable page to be rightly parsed for generation.

![image](https://user-images.githubusercontent.com/20978252/46464426-3a434180-c7be-11e8-81c4-223c58e45a3a.png)


Closes issue: NA
