### PR TITLE
Add examples of syntactically invalid language attributes

### DIFF
--- a/_rules/SC3-1-1-html-lang-valid.md
+++ b/_rules/SC3-1-1-html-lang-valid.md
@@ -113,6 +113,14 @@ Both the `lang` and `xml:lang` value specified are not valid values for primary 
 <html xml:lang="xyz" lang="xyz">
 ```
 
+#### Fail example 4
+
+The `lang` attribute value has a valid primary language subtag, but a syntactically invalid region subtag.
+
+```html
+<html lang="en-US_GB">
+```
+
 ## Inapplicable
 
 #### Inapplicable example 1

--- a/_rules/SC3-1-1-html-lang-valid.md
+++ b/_rules/SC3-1-1-html-lang-valid.md
@@ -118,7 +118,7 @@ Both the `lang` and `xml:lang` value specified are not valid values for primary 
 The `lang` attribute value has a valid primary language subtag, but a syntactically invalid region subtag.
 
 ```html
-<html lang="en-US_GB">
+<html lang="en-US-GB">
 ```
 
 ## Inapplicable

--- a/_rules/SC3-1-2-lang-valid.md
+++ b/_rules/SC3-1-2-lang-valid.md
@@ -121,7 +121,7 @@ The `lang` attribute value has a valid primary language subtag, but a syntactica
 ```html
 <html>
 <body>
-  <p data-rule-target lang="en-US_GB"></p>
+  <p data-rule-target lang="en-US-GB"></p>
 </body>
 </html>
 ```

--- a/_rules/SC3-1-2-lang-valid.md
+++ b/_rules/SC3-1-2-lang-valid.md
@@ -114,6 +114,18 @@ The `xml:lang` attribute value is not a valid primary language subtag.
 </html>
 ```
 
+#### Fail example 3
+
+The `lang` attribute value has a valid primary language subtag, but a syntactically invalid region subtag.
+
+```html
+<html>
+<body>
+  <p data-rule-target lang="en-US_GB"></p>
+</body>
+</html>
+```
+
 ### Inapplicable
 
 #### Inapplicable example 1


### PR DESCRIPTION
This PR adds two examples of language attribute values that are invalid due to syntax issues not in the primary language subtag, but the subtags following it. This is meant to counter naïve implementations of BCP47 parsing where the value is simply split on hyphens and the first value tested against the subtag registry, which I myself was guilty of 🙈 

As for why the examples are syntactially invalid: The region subtag is the only subtag that may consist of two alpha characters and only one region subtag may be included in a language tag.