### PR TITLE
Remove CSS Styling from test_aspects where not used

### DIFF
--- a/_rules/SC4-1-1+SC4-1-2-aria-allowed-attribute.md
+++ b/_rules/SC4-1-1+SC4-1-2-aria-allowed-attribute.md
@@ -9,7 +9,6 @@ success_criterion:
 
 test_aspects:
 - DOM Tree
-- CSS Styling
 
 authors:
 - Anne Thyme Nørregaard

--- a/_rules/SC4-1-2-role-has-required-states-and-properties.md
+++ b/_rules/SC4-1-2-role-has-required-states-and-properties.md
@@ -8,7 +8,6 @@ success_criterion:
 
 test_aspects:
 - DOM Tree
-- CSS Styling
 
 authors:
 - Anne Thyme Nørregaard


### PR DESCRIPTION
CSS Styling was listed as a test aspect in several rules where no styling information is used in either Applicability or Expectations.

Closes issue: none

# How to Review And Approve
- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
