### PR TITLE
Fix layout typo in keyboard-trap-standard-nav

### DIFF
--- a/_rules/SC2-1-2-no-keyboard-trap-standard-navigation.md
+++ b/_rules/SC2-1-2-no-keyboard-trap-standard-navigation.md
@@ -5,7 +5,7 @@ test_type: atomic
 description: |
   This rule checks if it is possible to use standard keyboard navigation to navigate through all content on a web page without becoming trapped in any element.
 
-test aspects:
+test_aspects:
 - DOM Tree
 - CSS Styling
 


### PR DESCRIPTION
Missing an underscore in test_aspects, which made the section not show up in the presentation on https://auto-wcag.github.io/auto-wcag/rules/SC2-1-2-no-keyboard-trap-standard-navigation.html

# How to Review And Approve
- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
