### PR TITLE
Image-has-name test cases should match Applicability

### DIFF
--- a/_rules/SC1-1-1-image-has-name.md
+++ b/_rules/SC1-1-1-image-has-name.md
@@ -93,14 +93,6 @@ HTML `img` element marked as [decorative](#decorative) through `role="none"`
 <img role="none" />
 ```
 
-#### Passed example 7
-
-HTML `img` element is not [included in the accessibility tree](#included-in-the-accessibility-tree) but has accessible name
-
-```html
-<img alt="W3C logo" aria-hidden="true" />
-```
-
 ### Failed
 
 #### Failed example 1
@@ -127,14 +119,6 @@ Image element inside a `div` positioned off screen with no accessible name and i
 <div style="margin-left:-9999px;"><img /></div>
 ```
 
-#### Failed example 4
-
-HTML `img` element is not [included in the accessibility tree](#included-in-the-accessibility-tree), does not have accessible name and is not marked as decorative
-
-```html
-<img aria-hidden="true" />
-```
-
 ### Inapplicable
 
 #### Inapplicable example 1
@@ -153,4 +137,12 @@ Element with [semantic role](#semantic-role) of `img` is not [included in the ac
 
 ```html
 <div role="img" aria-hidden="true"></div>
+```
+
+#### Inapplicable example 3
+
+HTML `img` element is not [included in the accessibility tree](#included-in-the-accessibility-tree) 
+
+```html
+<img alt="W3C logo" aria-hidden="true" />
 ```

--- a/_rules/SC1-1-1-image-has-name.md
+++ b/_rules/SC1-1-1-image-has-name.md
@@ -19,7 +19,7 @@ authors:
 
 ### Applicability
 
-The rule applies to HTML `img` elements or any HTML element with the [semantic role](#semantic-role) of `img` that is [included in the accessibility tree](#included-in-the-accessibility-tree).
+The rule applies to any HTML element with the [semantic role](#semantic-role) of `img` that is [included in the accessibility tree](#included-in-the-accessibility-tree), and any HTML `img` element.
 
 ### Expectation
 
@@ -63,10 +63,34 @@ Non-image element with image role and accessible name
 
 #### Passed example 3
 
-Accessible name but not always supported.
+Accessible name but not always accessibility supported.
 
 ```html
 <img title="W3C logo" />
+```
+
+#### Passed example 4
+
+HTML `img` element marked as decorative through empty `alt` attribute
+
+```html
+<img alt="" />
+```
+
+#### Passed example 5
+
+HTML `img` element marked as decorative through `role="presentation"`
+
+```html
+<img role="presentation" />
+```
+
+#### Passed example 6
+
+HTML `img` element marked as decorative through `role="none"`
+
+```html
+<img role="none" />
 ```
 
 ### Failed
@@ -97,34 +121,18 @@ Image element inside a div positioned off screen with no accessible name.
 
 #### Inapplicable example 1
 
-decorative image.
-
-```html
-<img alt="" />
-```
-
-#### Inapplicable example 2
-
-decorative image.
-
-```html
-<img role="presentation" />
-```
-
-#### Inapplicable example 3
-
-`img` element with no role.
-
-```html
-<img role="none" />
-```
-
-#### Inapplicable example 4
-
-Non-image element.
+Element that does not have the [semantic role](#semantic-role) of `img`
 
 ```svg
 <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
   <circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow" />
 </svg>
+```
+
+#### Inapplicable example 2
+
+Element with [semantic role](#semantic-role) of `img` is not [included in the accessibility tree](#included-in-the-accessibility-tree)
+
+```html
+<div role="img" aria-hidden="true"></div>
 ```

--- a/_rules/SC1-1-1-image-has-name.md
+++ b/_rules/SC1-1-1-image-has-name.md
@@ -19,7 +19,7 @@ authors:
 
 ### Applicability
 
-The rule applies to any HTML element with the [semantic role](#semantic-role) of `img` that is [included in the accessibility tree](#included-in-the-accessibility-tree), and any HTML `img` element.
+This rule applies to any HTML element with the [semantic role](#semantic-role) of `img` that is [included in the accessibility tree](#included-in-the-accessibility-tree), and any HTML `img` element.
 
 ### Expectation
 

--- a/_rules/SC1-1-1-image-has-name.md
+++ b/_rules/SC1-1-1-image-has-name.md
@@ -47,7 +47,7 @@ There is a known combination of a popular browser and assistive technology that 
 
 #### Passed example 1
 
-Image has accessible name
+HTML `img` element has accessible name
 
 ```html
 <img alt="W3C logo" />
@@ -55,7 +55,7 @@ Image has accessible name
 
 #### Passed example 2
 
-Non-image element with image role and accessible name
+Element with role of `img` and accessible name
 
 ```html
 <div role="img" aria-label="W3C logo"></div>
@@ -71,7 +71,7 @@ Accessible name but not always accessibility supported
 
 #### Passed example 4
 
-HTML `img` element marked as decorative through empty `alt` attribute
+HTML `img` element marked as [decorative](#decorative) through empty `alt` attribute
 
 ```html
 <img alt="" />
@@ -79,7 +79,7 @@ HTML `img` element marked as decorative through empty `alt` attribute
 
 #### Passed example 5
 
-HTML `img` element marked as decorative through `role="presentation"`
+HTML `img` element marked as [decorative](#decorative) through `role="presentation"`
 
 ```html
 <img role="presentation" />
@@ -87,17 +87,25 @@ HTML `img` element marked as decorative through `role="presentation"`
 
 #### Passed example 6
 
-HTML `img` element marked as decorative through `role="none"`
+HTML `img` element marked as [decorative](#decorative) through `role="none"`
 
 ```html
 <img role="none" />
+```
+
+#### Passed example 7
+
+HTML `img` element is not [included in the accessibility tree](#included-in-the-accessibility-tree) but has accessible name
+
+```html
+<img alt="W3C logo" aria-hidden="true" />
 ```
 
 ### Failed
 
 #### Failed example 1
 
-No accessible name
+No accessible name and is not marked as [decorative](#decorative)
 
 ```html
 <img />
@@ -113,10 +121,18 @@ Non-image element with image role but no accessible name
 
 #### Failed example 3
 
-Image element inside a div positioned off screen with no accessible name
+Image element inside a `div` positioned off screen with no accessible name and is not marked as [decorative](#decorative)
 
 ```html
 <div style="margin-left:-9999px;"><img /></div>
+```
+
+#### Failed example 4
+
+HTML `img` element is not [included in the accessibility tree](#included-in-the-accessibility-tree), does not have accessible name and is not marked as decorative
+
+```html
+<img aria-hidden="true" />
 ```
 
 ### Inapplicable

--- a/_rules/SC1-1-1-image-has-name.md
+++ b/_rules/SC1-1-1-image-has-name.md
@@ -97,7 +97,7 @@ HTML `img` element marked as [decorative](#decorative) through `role="none"`
 
 #### Failed example 1
 
-No accessible name and is not marked as [decorative](#decorative)
+HTML `img` element that is not marked as [decorative](#decorative) and does not have accessible name
 
 ```html
 <img />

--- a/_rules/SC1-1-1-image-has-name.md
+++ b/_rules/SC1-1-1-image-has-name.md
@@ -19,7 +19,7 @@ authors:
 
 ### Applicability
 
-This rule applies to any HTML element with the [semantic role](#semantic-role) of `img` that is [included in the accessibility tree](#included-in-the-accessibility-tree), and any HTML `img` element.
+The rule applies to HTML `img` elements or any HTML element with the [semantic role](#semantic-role) of `img` that is [included in the accessibility tree](#included-in-the-accessibility-tree).
 
 ### Expectation
 

--- a/_rules/SC1-1-1-image-has-name.md
+++ b/_rules/SC1-1-1-image-has-name.md
@@ -105,7 +105,7 @@ No accessible name and is not marked as [decorative](#decorative)
 
 #### Failed example 2
 
-Non-image element with image role but no accessible name
+Element with role of `img` but no accessible name
 
 ```html
 <div role="img"></div>

--- a/_rules/SC1-1-1-image-has-name.md
+++ b/_rules/SC1-1-1-image-has-name.md
@@ -63,7 +63,7 @@ Non-image element with image role and accessible name
 
 #### Passed example 3
 
-Accessible name but not always accessibility supported.
+Accessible name but not always accessibility supported
 
 ```html
 <img title="W3C logo" />
@@ -105,14 +105,16 @@ No accessible name
 
 #### Failed example 2
 
-Non-image element with image role but no accessible name.
+Non-image element with image role but no accessible name
+
 ```html
 <div role="img"></div>
 ```
 
 #### Failed example 3
 
-Image element inside a div positioned off screen with no accessible name.
+Image element inside a div positioned off screen with no accessible name
+
 ```html
 <div style="margin-left:-9999px;"><img /></div>
 ```


### PR DESCRIPTION
Cleaned up test cases to match Applicability and clarified Applicability a bit to avoid more misunderstandings like that.

Closes issue: https://github.com/auto-wcag/auto-wcag/issues/292

> The first three examples of inapplicable images for https://auto-wcag.github.io/auto-wcag/rules/SC1-1-1-image-has-name.html are all passes according to the rule as they're <img> elements that have been marked as decorative.

# How to Review And Approve
- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
