### PR TITLE
Remove "focusable" from button-has-name Appl.

### DIFF
--- a/_rules/SC4-1-2-button-has-name.md
+++ b/_rules/SC4-1-2-button-has-name.md
@@ -20,7 +20,7 @@ authors:
 
 ### Applicability
 
-The rule applies to elements that are [visible on the page](#visible-on-the-page), [included in the accessibility tree](#included-in-the-accessibility-tree), or [focusable](#focusable) with the [semantic role](#semantic-role) of `button`, except for `input` elements of `type="image"`.
+The rule applies to elements that are [visible on the page](#visible-on-the-page) or [included in the accessibility tree](#included-in-the-accessibility-tree) with the [semantic role](#semantic-role) of `button`, except for `input` elements of `type="image"`.
 
 ### Expectation
 


### PR DESCRIPTION
Per @kasperisager's comment: 

> Per #281 and #269 (comment), SC4-1-2-aria-hidden-focus currently overlaps with several rules:
> 
> SC3-3-2-form-field-has-name
> SC2-4-4-link-has-name
> SC4-1-2-button-has-name
> It is possible for an element to be applicable to and pass any of the above rules, and then fail SC4-1-2-aria-hidden-focus for the same reason the element was applicable to the other rules in the first place. Together, these rules are effectively saying that, sure, you must have accessible names for these types of elements if they're focusable, but the accessible names won't ever be announced to AT because, guess what, you haven't included the elements in the accessibility tree. That seems a little backwards.
> 
> I'm thinking it would make more sense for SC4-1-2-aria-hidden-focus to first flag elements that are focusable, but not included in the accessibility tree, and if authors then do decide to include the elements in the accessibility tree, the other rules should then kick in to ensure that the elements also have accessible names.
> 
> I have similar concerns for these rules, which also apply to focusable elements that aren't included in the accessibility tree:
> 
> SC1-2-2-audio-captions
> SC1-3-5-autocomplete-valid 

Closes issue: #301

# How to Review And Approve
- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
