### PR TITLE
Add SC 4.1.2 to form-field-has-name

### DIFF
--- a/_rules/SC3-3-2+SC4-1-2-form-field-has-name.md
+++ b/_rules/SC3-3-2+SC4-1-2-form-field-has-name.md
@@ -5,6 +5,7 @@ description: |
 
 success_criterion:
 - 3.3.2 # Labels or Instructions
+- 4.1.2 # Name, Role, Value
 
 test_aspects:
 - DOM Tree


### PR DESCRIPTION
Adding 4.1.2 (Name, Role Value) as a SC in addition to 3.3.2 (Labels or Instructions).

Please consider this in relation to the accessibility requirements for the following rules:
- button-has-name only references SC 4.1.2: https://auto-wcag.github.io/auto-wcag/rules/SC4-1-2-button-has-name.html
- link-has-name both reference 2.4.4 Link Purpose (In Context) and 4.1.2: https://auto-wcag.github.io/auto-wcag/rules/SC2-4-4-link-has-name.html

Closes issue: #313 

# How to Review And Approve
- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
