### PR TITLE
chore: change references to included in accessibility tree

### DIFF
--- a/_rules/SC1-2-1-media-alternative-audio.md
+++ b/_rules/SC1-2-1-media-alternative-audio.md
@@ -20,7 +20,7 @@ authors:
 
 The rule applies to any [non-streaming](#non-streaming-media-element) `audio` element that is playing or with a "play button".
 
-A play button is an interactive element that when activated, plays the audio. The play button must be ]visibile on the page](#visible-on-the-page) or [exposed to assistive technologies](#exposed-to-assistive-technologies)
+A play button is an interactive element that when activated, plays the audio. The play button must be ]visibile on the page](#visible-on-the-page) or [included in the accessibility tree](#included-in-the-accessibility-tree)
 
 ### Expectation 1
 
@@ -32,7 +32,7 @@ Each target element has a label indicating the `audio` is an alternative to text
 
 ### Expectation 3
 
-The label (from expectation 2) is [visible on the page](#visible-on-the-page) and [exposed to assistive technolgies](#exposed-to-assistive-technologies)
+The label (from expectation 2) is [visible on the page](#visible-on-the-page) and [included in the accessibility tree](#included-in-the-accessibility-tree)
 
 ## Assumptions
 

--- a/_rules/SC1-2-1-media-alternative-video.md
+++ b/_rules/SC1-2-1-media-alternative-video.md
@@ -30,7 +30,7 @@ Each target element has a label indicating the `video` is an alternative to text
 
 ### Expectation 3
 
-The label (from expectation 2) is [visible on the page](#visible-on-the-page) and [exposed to assistive technolgies](#exposed-to-assistive-technologies)
+The label (from expectation 2) is [visible on the page](#visible-on-the-page) and [included in the accessibility tree](#included-in-the-accessibility-tree)
 
 ## Assumptions
 

--- a/_rules/SC2-4-4-link-has-name.md
+++ b/_rules/SC2-4-4-link-has-name.md
@@ -198,7 +198,7 @@ Non-visible link.
 
 #### Failed example 8
 
-Not exposed to assistive technologies.
+Not included in the accessibility tree.
 
 ```html
 <a href="http://www.w3.org/WAI" aria-hidden="true"><img src="#" /></a>

--- a/_rules/SC4-1-1-unique-id.md
+++ b/_rules/SC4-1-1-unique-id.md
@@ -22,7 +22,7 @@ authors:
 
 Any element that has an `id` attribute.
 
-**Note:** Elements that are neither [exposed to assistive technologies](#exposed-to-assistive-technologies) nor [visible on the page](#visible-on-the-page) are still considered for this rule.
+**Note:** Elements that are neither [included in the accessibility tree](#included-in-the-accessibility-tree) nor [visible on the page](#visible-on-the-page) are still considered for this rule.
 
 ### Expectation
 

--- a/_rules/SC4-1-2-button-has-name.md
+++ b/_rules/SC4-1-2-button-has-name.md
@@ -168,7 +168,7 @@ Image buttons are tested in a different rule
 
 #### Inapplicable example 2
 
-Not visible in page and not exposed to assistive technologies.
+Not visible in page and not included in the accessibility tree.
 
 ```html
 <html>

--- a/_rules/SC4-1-2-iframe-has-name.md
+++ b/_rules/SC4-1-2-iframe-has-name.md
@@ -19,7 +19,7 @@ authors:
 
 ### Applicability
 
-The rule applies to `iframe` elements that are [exposed to assistive technologies](#exposed-to-assistive-technologies).
+The rule applies to `iframe` elements that are [included in the accessibility tree](#included-in-the-accessibility-tree).
 
 **Note:** `frame` element is deprecated, this rule does not consider `frame` or `frameset` elements.
 
@@ -142,7 +142,7 @@ Does not apply to non `iframe` element.
 
 #### Inapplicable example 2
 
-`iframe` is not exposed to assistive technologies.
+`iframe` is not included in the accessibility tree.
 
 ```html
 <iframe style="display:none;" src="../test-assets/SC4-1-2-frame-doc.html">

--- a/_rules/SC4-1-2-role-attribute-has-valid-value.md
+++ b/_rules/SC4-1-2-role-attribute-has-valid-value.md
@@ -20,7 +20,7 @@ authors:
 
 ### Applicability
 
-Any [non-empty](#non-empty) `role` attribute that is specified on an HTML or SVG element that is [exposed to assistive technologies](#exposed-to-assistive-technologies).
+Any [non-empty](#non-empty) `role` attribute that is specified on an HTML or SVG element that is [included in the accessibility tree](#included-in-the-accessibility-tree).
 
 **Note:** Having a whitespace separated list of more than one token in the value of the role attribute is used for what is known as _fallback roles_. If the first token is not accessibility supported (or valid), the next one will be used for determining the [semantic role](#semantic-role) of the element, and so forth.
 
@@ -118,7 +118,7 @@ Element with null `role` attribute.
 
 #### Inapplicable example 4
 
-Element that is not exposed to assistive technologies.
+Element that is not included in the accessibility tree.
 
 ```html
 <div aria-hidden="true" role="banner">Some Content</div>

--- a/pages/algorithms/accessible-name.md
+++ b/pages/algorithms/accessible-name.md
@@ -3,7 +3,7 @@ title: Accessible Name
 key: accessible-name
 ---
 
-The programatically determined name of a user interface element that is exposed to assistive technologies.
+The programatically determined name of a user interface element that is included in the accessibility tree.
 
 The accessible name is calculated using the [accessible name computation](https://www.w3.org/TR/accname).
 

--- a/pages/design/definition-of-done.md
+++ b/pages/design/definition-of-done.md
@@ -20,7 +20,7 @@ The Definition of "Done" is a living document, and might change as the rule writ
 - Requirements for use of atomic and composed rules are followed, see [Rule Types](https://www.w3.org/TR/act-rules-format/#rule-types) in the [ACT Rules Format](https://www.w3.org/TR/act-rules-format/)
 - The rule follows the Auto-WCAG [rule template](/design/rule-template.html), especially in relation to headings, styling, test case descriptions, etc.
 - The rule is using Auto-WCAG [Glossary terms](https://auto-wcag.github.io/auto-wcag/pages/algorithms/) whenever possible. Be particularly aware of the following much-used algorithms:
-    - For the Applicability, consider if the definitions [exposed to assistive technologies](#exposed-to-assistive-technologies) and [visible on the page](#visible-on-the-page) should be used to narrow down the scope of the rule.
+    - For the Applicability, consider if the definitions [included in the accessibility tree](#included-in-the-accessibility-tree) and [visible on the page](#visible-on-the-page) should be used to narrow down the scope of the rule.
     - For the Applicability and Expectations, consider if the definition for [semantic role](#semantic-role) (including specifics of explicit and implicit semantic role) could be used to describe the targets of the rule.
 - The rule links to any relevant documentation, e.g. [Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/) and [Techniques for WCAG 2.0](https://www.w3.org/TR/WCAG-TECHS/), specifications used, etc.
 - The name of the rule is written in plain language, with capitalized initial letter


### PR DESCRIPTION
Fixing up following @annethyme PR - https://github.com/auto-wcag/auto-wcag/pull/269, where certain references to `exposed to assistive technology` were not updated to `included in accessibility tree`

Closes issue: NA