### PR TITLE
chore: remove selector `data-rule-target`

### DIFF
--- a/_plugins/codesnippetframe_and_testcases_generator.rb
+++ b/_plugins/codesnippetframe_and_testcases_generator.rb
@@ -146,13 +146,6 @@ module Jekyll
 			doc_name = doc_name_with_type.gsub('.html', '').gsub('.svg', '')
 			doc_path = document.url.sub(doc_name_with_type, '')
 			doc_scs = document["success_criterion"]
-			doc_testcases_sc_meta = []
-			if(doc_scs != nil)
-				doc_scs.each do |sc|
-					doc_testcases_sc_meta.push(SC_DATA[sc]["scId"])
-				end
-			end
-		
 			all_indices = get_code_tag_line_indices(document)
 			indices =  all_indices[0]
 			spread_indices = all_indices[1]
@@ -193,17 +186,9 @@ module Jekyll
 					# constuct a hash which contains all the 
 					# code-snippet and iframe embedded
 					embedded_testcases_hash[indices[$i].to_s] = render_code_and_frame(file_content, file_url, should_not_render_frame)
-					testcase_url = file_url.gsub('../_testcases-embeds/', 'assets/')
-					testcase_selector = "body > :first-child"
-					if file_content.include? "data-rule-target"
-						testcase_selector = "*[data-rule-target]"
-					end
-				
+					testcase_url = file_url.gsub('../_testcases-embeds/', 'assets/')				
 					tc_meta = {}
-					tc_meta["selector"] = testcase_selector
 					tc_meta["url"] = testcase_url
-					tc_meta["successCriteria"] = doc_testcases_sc_meta
-
 					testcases[test_case_type.to_s].push(tc_meta)
 
 					# write iframe content to file
@@ -233,9 +218,6 @@ module Jekyll
 					# create test-case object
 					t = {}
 					t['url'] = "#{PKG['config']['site-url-prefix']}/#{PKG['config']['testcases-export-dir']}#{meta["url"]}" 
-					t['relativeUrl'] = meta["url"]
-					t['successCriteria'] = meta["successCriteria"]
-					t['selector'] = meta["selector"]
 					t['expected'] = tc_type.to_s
 					t['ruleId'] = rule_id
 					t['rulePage'] = "#{PKG['config']['site-url-prefix']}/rules/#{rule_id}.html"

--- a/_rules/SC1-2-1-media-alternative-audio.md
+++ b/_rules/SC1-2-1-media-alternative-audio.md
@@ -57,7 +57,7 @@ An audio element that describes some of the text on the same page. The text on t
 ```html
 <p>A part of a speech by John F. Kennedy: We choose to go to the moon in this decade and do the other things, not because they are easy, but because they are hard, because that goal will serve to organize and measure the best of our energies and skills, because that challenge is one that we are willing to accept, one we are unwilling to postpone, and one which we intend to win, and the others, too.</p>
 <p>You can also listen to the audio file below to hear the above part of the speech.</p>
-<audio data-rule-target src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
 ```
 
 ### Failed
@@ -69,7 +69,7 @@ An audio element that describes some of the text on the same page. The audio con
 ```html
 <p>A part of a speech by John F. Kennedy: We choose to go to the moon in this decade and do the other things, not because they are easy, but because they are hard.</p>
 <p>You can also listen to the audio file below to hear the above part of the speech.</p>
-<audio data-rule-target src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
 ```
 
 #### Failed example 2
@@ -79,7 +79,7 @@ An audio element that describes some of the text on the same page. The text is n
 ```html
 <p style="display: none;">A part of a speech by John F. Kennedy: We choose to go to the moon in this decade and do the other things, not because they are easy, but because they are hard, because that goal will serve to organize and measure the best of our energies and skills, because that challenge is one that we are willing to accept, one we are unwilling to postpone, and one which we intend to win, and the others, too.</p>
 <p>You can also listen to the audio file below to hear the above part of the speech.</p>
-<audio data-rule-target src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
 ```
 
 #### Failed example 3
@@ -88,7 +88,7 @@ An audio element that describes some of the text on the same page. The text on t
 
 ```html
 <p>A part of a speech by John F. Kennedy: We choose to go to the moon in this decade and do the other things, not because they are easy, but because they are hard, because that goal will serve to organize and measure the best of our energies and skills, because that challenge is one that we are willing to accept, one we are unwilling to postpone, and one which we intend to win, and the others, too.</p>
-<audio data-rule-target src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
 ```
 
 #### Failed example 4
@@ -98,7 +98,7 @@ An audio element that describes some of the text on the same page. The text on t
 ```html
 <p>A part of a speech by John F. Kennedy: We choose to go to the moon in this decade and do the other things, not because they are easy, but because they are hard, because that goal will serve to organize and measure the best of our energies and skills, because that challenge is one that we are willing to accept, one we are unwilling to postpone, and one which we intend to win, and the others, too.</p>
 <p style="display: none;">You can also listen to the audio file below to hear the above part of the speech.</p>
-<audio data-rule-target src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
 ```
 
 ### Inapplicable
@@ -110,7 +110,7 @@ An audio element that describes some of the text on the same page. The text on t
 ```html
 <p>A part of a speech by John F. Kennedy: We choose to go to the moon in this decade and do the other things, not because they are easy, but because they are hard, because that goal will serve to organize and measure the best of our energies and skills, because that challenge is one that we are willing to accept, one we are unwilling to postpone, and one which we intend to win, and the others, too.</p>
 <p>You can also listen to the audio file below to hear the above part of the speech.</p>
-<audio data-rule-target src="../test-assets/moon-audio/moon-speech.mp3" controls style="display: none;"> </audio>
+<audio src="../test-assets/moon-audio/moon-speech.mp3" controls style="display: none;"> </audio>
 ```
 
 #### Inapplicable example 2
@@ -120,5 +120,5 @@ An audio element that describes some of the text on the same page. The text on t
 ```html
 <p>A part of a speech by John F. Kennedy: We choose to go to the moon in this decade and do the other things, not because they are easy, but because they are hard, because that goal will serve to organize and measure the best of our energies and skills, because that challenge is one that we are willing to accept, one we are unwilling to postpone, and one which we intend to win, and the others, too.</p>
 <p>You can also listen to the audio file below to hear the above part of the speech.</p>
-<audio data-rule-target src="../test-assets/moon-audio/moon-speech.mp3" > </audio>
+<audio src="../test-assets/moon-audio/moon-speech.mp3" > </audio>
 ```

--- a/_rules/SC1-2-1-media-alternative-video.md
+++ b/_rules/SC1-2-1-media-alternative-video.md
@@ -58,7 +58,7 @@ A video element without audio. The text on the page labels the video as an alter
   websites. Either through preference or circumstance. This is solved by keyboard compatibility. 
   Keyboard compatibility is described in WCAG.
   See the video below to watch the same information again in video form.</p>
-<video data-rule-target src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls>
+<video src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls>
 </video>
 ```
 
@@ -74,7 +74,7 @@ A video element that describes some of the text on the same page. The video cont
   doesn't work, is frustrating. Either through preference or circumstance. This is solved by keyboard compatibility. 
   Keyboard compatibility is described in WCAG.
   See the video below to watch the same information again in video form.</p>
-<video data-rule-target src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls>
+<video src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls>
 </video>
 ```
 
@@ -88,7 +88,7 @@ A video element that describes some of the text on the same page. The text is no
   websites. Either through preference or circumstance. This is solved by keyboard compatibility. 
   Keyboard compatibility is described in WCAG.
   See the video below to watch the same information again in video form.</p>
-<video data-rule-target src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls>
+<video src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls>
 </video>
 ```
 
@@ -101,7 +101,7 @@ A video element that describes some of the text on the same page. The text on th
   doesn't work, is frustrating. Many people use only the keyboard to navigate 
   websites. Either through preference or circumstance. This is solved by keyboard compatibility. 
   Keyboard compatibility is described in WCAG.</p>
-<video data-rule-target src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls>
+<video src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls>
 </video>
 ```
 
@@ -115,7 +115,7 @@ A video element that describes some of the text on the same page. The text on th
   websites. Either through preference or circumstance. This is solved by keyboard compatibility. 
   Keyboard compatibility is described in WCAG.</p>
   <p style="display: none;">See the video below to watch the same information again in video form.</p>
-<video data-rule-target src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls>
+<video src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls>
 </video>
 ```
 
@@ -131,7 +131,7 @@ A video element with audio.
   websites. Either through preference or circumstance. This is solved by keyboard compatibility. 
   Keyboard compatibility is described in WCAG.
   See the video below to watch the same information again in video form.</p>
-<video data-rule-target src="../test-assets/perspective-video/perspective-keyboard-compatibility-video.mp4" controls>
+<video src="../test-assets/perspective-video/perspective-keyboard-compatibility-video.mp4" controls>
 </video>
 ```
 
@@ -145,6 +145,6 @@ A video element that describes some of the text on the same page. The text on th
   websites. Either through preference or circumstance. This is solved by keyboard compatibility. 
   Keyboard compatibility is described in WCAG.
   See the video below to watch the same information again in video form.</p>
-<video data-rule-target src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls style="display: none;">
+<video src="../test-assets/perspective-video/perspective-video-with-captions-silent.mp4" controls style="display: none;">
 </video>
 ```

--- a/_rules/SC1-2-2-audio-captions.md
+++ b/_rules/SC1-2-2-audio-captions.md
@@ -51,7 +51,7 @@ While the HTML specifications allows the use of `track` elements inside of `audi
 Audio with controls and internal transcript
 
 ```html
-<audio data-rule-target src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
 <p>The above audio contains the following speech: We choose to go to the moon in this decade and do the other things, not because they are easy, but because they are hard, because that goal will serve to organize and measure the best of our energies and skills, because that challenge is one that we are willing to accept, one we are unwilling to postpone, and one which we intend to win, and the others, too.</p>
 ```
 
@@ -60,7 +60,7 @@ Audio with controls and internal transcript
 Audio with controls and external transcript
 
 ```html
-<audio data-rule-target src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
 <a href="/test-assets/moon-audio/moon-speech-transcript.html">Transcript</p>
 ```
 
@@ -69,7 +69,7 @@ Audio with controls and external transcript
 Audio with autoplay, external transcript, and with a text description on the page
 
 ```html (no-iframe)
-<audio data-rule-target src="../test-assets/moon-audio/moon-speech.mp3" autoplay></audio>
+<audio src="../test-assets/moon-audio/moon-speech.mp3" autoplay></audio>
 <a href="/test-assets/moon-audio/moon-speech-transcript.html">Transcript</p>
 ```
 
@@ -80,7 +80,7 @@ Audio with autoplay, external transcript, and with a text description on the pag
 Audio with controls and incorrect internal transcript
 
 ```html
-<audio data-rule-target src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
 <p>The above audio contains the following speech: We choose to go to the cheese in this decade and do the other things, not because they are easy, but because they are hard, because that goal will serve to organize and measure the best of our energies and skills, because that challenge is one that we are willing to accept, one we are unwilling to postpone, and one which we intend to win, and the others, too.</p>
 ```
 
@@ -89,7 +89,7 @@ Audio with controls and incorrect internal transcript
 Audio with controls and incorrect external transcript
 
 ```html
-<audio data-rule-target src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
+<audio src="../test-assets/moon-audio/moon-speech.mp3" controls></audio>
 <a href="/test-assets/moon-audio/moon-speech-incorrect-transcript.html">Transcript</p>
 ```
 
@@ -98,7 +98,7 @@ Audio with controls and incorrect external transcript
 Audio with autoplay and incorrect external transcript
 
 ```html (no-iframe)
-<audio data-rule-target src="../test-assets/moon-audio/moon-speech.mp3" autoplay></audio>
+<audio src="../test-assets/moon-audio/moon-speech.mp3" autoplay></audio>
 <a href="/test-assets/moon-audio/moon-speech-incorrect-transcript.html">Transcript</p>
 ```
 

--- a/_rules/SC1-2-video-audio-description.md
+++ b/_rules/SC1-2-video-audio-description.md
@@ -65,7 +65,7 @@ A video element with an audio description.
 
 <figure id="ozplayer-1-container" class="ozplayer-container">
   <div data-controls="stack" class="ozplayer" id="ozplayer-1">
-    <video data-rule-target controls="controls" preload="none">
+    <video controls="controls" preload="none">
       <source src="../test-assets/rabbit-video.mp4" type="video/mp4"></source>
     </video>
     <audio data-default="default" preload="none">
@@ -115,7 +115,7 @@ A video element with an incorrect audio description.
 
 <figure id="ozplayer-1-container" class="ozplayer-container">
   <div data-controls="stack" class="ozplayer" id="ozplayer-1">
-    <video data-rule-target controls="controls" preload="none">
+    <video controls="controls" preload="none">
       <source src="../test-assets/rabbit-video/video.mp4" type="video/mp4"></source>
     </video>
     <audio data-default="default" preload="none">

--- a/_rules/SC1-2-video-transcript.md
+++ b/_rules/SC1-2-video-transcript.md
@@ -59,7 +59,7 @@ There are no major accessibility support issues known for this rule.
 A video element with a text transcript on the same page.
 
 ```html
-<video controls data-rule-target>
+<video controls>
   <source src="../test-assets/rabbit-video/video.mp4" type="video/mp4"></source>
   <source src="../test-assets/rabbit-video/video.webm" type="video/webm"></source>
 </video>
@@ -73,7 +73,7 @@ Then he stops to scratch his bottom.</p>
 A video element with a link to a text transcript on a different page.
 
 ```html
-<video controls data-rule-target>
+<video controls>
   <source src="../test-assets/rabbit-video/video.mp4" type="video/mp4"></source>
   <source src="../test-assets/rabbit-video/video.webm" type="video/webm"></source>
 </video>
@@ -87,7 +87,7 @@ A video element with a link to a text transcript on a different page.
 A video element with an incorrect text transcript on the same page.
 
 ```html
-<video controls data-rule-target>
+<video controls>
   <source src="../test-assets/rabbit-video/video.mp4" type="video/mp4"></source>
   <source src="../test-assets/rabbit-video/video.webm" type="video/webm"></source>
 </video>
@@ -101,7 +101,7 @@ Then he stops to scratch his bottom.</p>
 A video element with a link to an incorrect text transcript on a different page.
 
 ```html
-<video controls data-rule-target>
+<video controls>
   <source src="../test-assets/rabbit-video/video.mp4" type="video/mp4"></source>
   <source src="../test-assets/rabbit-video/video.webm" type="video/webm"></source>
 </video>
@@ -115,7 +115,7 @@ A video element with a link to an incorrect text transcript on a different page.
 A video element that is not visible on the page.
 
 ```html
-<video controls style="display: none;" data-rule-target>
+<video controls style="display: none;">
   <source src="../test-assets/rabbit-video/video.mp4" type="video/mp4"></source>
   <source src="../test-assets/rabbit-video/video.webm" type="video/webm"></source>
 </video>
@@ -127,7 +127,7 @@ A video element that is not visible on the page.
 A video element without audio.
 
 ```html
-<video controls data-rule-target>
+<video controls>
   <source src="../test-assets/rabbit-video/silent.mp4" type="video/mp4"></source>
   <source src="../test-assets/rabbit-video/silent.webm" type="video/webm"></source>
 </video>

--- a/_rules/SC2-2-1+SC2-2-4-meta-refresh.md
+++ b/_rules/SC2-2-1+SC2-2-4-meta-refresh.md
@@ -53,7 +53,7 @@ Redirects immediately.
 
 ```html
   <head>           
-    <meta data-rule-target http-equiv="refresh" content="0; URL='https://auto-wcag.github.io/auto-wcag/'" />    
+    <meta http-equiv="refresh" content="0; URL='https://auto-wcag.github.io/auto-wcag/'" />    
   </head>  
 ```
 
@@ -63,8 +63,8 @@ First valid `<meta http-equiv="refresh">` redirects immediately.
 
 ```html
 <head>
-  <meta data-rule-target http-equiv="refresh" content="0; http://example.com" />
-  <meta data-rule-target http-equiv="refresh" content="5; http://example.com" />
+  <meta http-equiv="refresh" content="0; http://example.com" />
+  <meta http-equiv="refresh" content="5; http://example.com" />
 </head>
 ```
 
@@ -74,7 +74,7 @@ Redirects after more than 20 hours.
 
 ```html
 <head>
-  <meta data-rule-target http-equiv="refresh" content="72001; http://example.com" />
+  <meta http-equiv="refresh" content="72001; http://example.com" />
 </head>
 ```
 
@@ -86,7 +86,7 @@ Refreshes after 30 seconds.
 
 ```html
 <head>
-	<meta data-rule-target http-equiv="refresh" content="30">
+	<meta http-equiv="refresh" content="30">
 </head>
 ```
 
@@ -96,7 +96,7 @@ Redirects after 30 seconds.
 
 ```html
 <head>
-	<meta data-rule-target http-equiv="refresh" content="30; URL='https://auto-wcag.github.io/auto-wcag/'">
+	<meta http-equiv="refresh" content="30; URL='https://auto-wcag.github.io/auto-wcag/'">
 </head>
 ```
 
@@ -106,8 +106,8 @@ First `<meta http-equiv="refresh">` element is not valid, second one redirects a
 
 ```html
 <head>
-  <meta data-rule-target http-equiv="refresh" content="0: http://example.com" />
-  <meta data-rule-target http-equiv="refresh" content="5; http://example.com" />
+  <meta http-equiv="refresh" content="0: http://example.com" />
+  <meta http-equiv="refresh" content="5; http://example.com" />
 </head>
 ```
 
@@ -117,7 +117,7 @@ Redirects after exactly 20 hours.
 
 ```html
 <head>
-  <meta data-rule-target http-equiv="refresh" content="72000; http://example.com" />
+  <meta http-equiv="refresh" content="72000; http://example.com" />
 </head>
 ```
 
@@ -129,7 +129,7 @@ No `content` attribute.
 
 ```html
 <head>
-	<meta data-rule-target http-equiv="refresh">
+	<meta http-equiv="refresh">
 </head>
 ```
 
@@ -139,7 +139,7 @@ No `http-equiv="refresh"` attribute.
 
 ```html
 <head>
-	<meta data-rule-target content="30">
+	<meta content="30">
 </head>
 ```
 
@@ -149,7 +149,7 @@ No `http-equiv="refresh"` attribute.
 
 ```html
 <head>
-  <meta data-rule-target http-equiv="refresh" content="0: http://example.com" />
+  <meta http-equiv="refresh" content="0: http://example.com" />
 </head>
 ```
 
@@ -159,7 +159,7 @@ No `http-equiv="refresh"` attribute.
 
 ```html
 <head>
-	<meta data-rule-target http-equiv=refresh content="-00.12 foo">
+	<meta http-equiv=refresh content="-00.12 foo">
 </head>
 ```
 
@@ -169,7 +169,7 @@ No `http-equiv="refresh"` attribute.
 
 ```html
 <head>
-	<meta data-rule-target http-equiv="refresh" content="; 30">
+	<meta http-equiv="refresh" content="; 30">
 </head>
 ```
 
@@ -178,7 +178,7 @@ No `http-equiv="refresh"` attribute.
 `content` attribute is invalid and therefore inapplicable.
 ```html
 <head>
-	<meta data-rule-target http-equiv="refresh" content="">
+	<meta http-equiv="refresh" content="">
 </head>
 ```
 
@@ -188,7 +188,7 @@ No `http-equiv="refresh"` attribute.
 
 ```html
 <head>
-  <meta data-rule-target http-equiv="refresh" content="+5; http://example.com">
+  <meta http-equiv="refresh" content="+5; http://example.com">
 </head>
 ```
 
@@ -198,6 +198,6 @@ No `http-equiv="refresh"` attribute.
 
 ```html
 <head>           
-  <meta data-rule-target http-equiv="refresh" content="foo; URL='https://auto-wcag.github.io/auto-wcag/'" />    
+  <meta http-equiv="refresh" content="foo; URL='https://auto-wcag.github.io/auto-wcag/'" />    
 </head>
 ```

--- a/_rules/SC2-4-4-link-has-name.md
+++ b/_rules/SC2-4-4-link-has-name.md
@@ -124,7 +124,7 @@ When `link` is off screen.
     }
   </style>
   <body>
-		<a data-rule-target class="offScreenLink" href="http://www.w3.org/WAI"> Web Accessibility Initiative (WAI) </a>
+		<a class="offScreenLink" href="http://www.w3.org/WAI"> Web Accessibility Initiative (WAI) </a>
   </body>
 </html>
 ```

--- a/_rules/SC3-1-2-lang-valid.md
+++ b/_rules/SC3-1-2-lang-valid.md
@@ -47,7 +47,7 @@ The `lang` attribute specified has a non-empty value & a valid primary language 
 ```html
 <html>
 <body> 
-  <article data-rule-target lang="en"></article>
+  <article lang="en"></article>
 </body>
 </html>
 ```
@@ -59,7 +59,7 @@ The `xml:lang` attribute specified has a non-empty value & a valid primary langu
 ```html
 <html>
 <body>
-  <p data-rule-target xml:lang="DE"></p>
+  <p xml:lang="DE"></p>
 </body>
 </html>
 ```
@@ -71,7 +71,7 @@ The `lang` attribute specified has a non-empty value & a valid primary language 
 ```html
 <html>
 <body>
-  <blockquote data-rule-target lang="fr-CH"></blockquote>
+  <blockquote lang="fr-CH"></blockquote>
 </body>
 </html>
 ```
@@ -83,7 +83,7 @@ The `lang` and `xml:lang` attribute specified has a non-empty value & a valid pr
 ```html
 <html>
 <body>
-  <p data-rule-target lang="en" xml:lang="en-GB">Good Morning.</p>
+  <p lang="en" xml:lang="en-GB">Good Morning.</p>
 </body>
 </html>
 ```
@@ -97,7 +97,7 @@ The `lang` attribute value is not a valid primary language subtag.
 ```html
 <html>
 <body>
-  <article data-rule-target lang="dutch"></article>
+  <article lang="dutch"></article>
 </body>
 </html>
 ```
@@ -109,7 +109,7 @@ The `xml:lang` attribute value is not a valid primary language subtag.
 ```html
 <html>
 <body>
-  <p data-rule-target xml:lang="english"></p>
+  <p xml:lang="english"></p>
 </body>
 </html>
 ```
@@ -121,7 +121,7 @@ The `lang` attribute value has a valid primary language subtag, but a syntactica
 ```html
 <html>
 <body>
-  <p data-rule-target lang="en-US-GB"></p>
+  <p lang="en-US-GB"></p>
 </body>
 </html>
 ```
@@ -135,7 +135,7 @@ The rule applies to elements with the `body` of a webpage. `html` elements are i
 
 ```html
 <html lang="en">
-	<body data-rule-target>
+	<body>
 	</body>
 </html>
 ```
@@ -147,7 +147,7 @@ An empty value for `lang` attribute is ignored by this rule, as the applicabilit
 ```html
 <html>
 	<body>
-		<article data-rule-target lang=""></article>
+		<article lang=""></article>
 	</body>
 </html>
 ```
@@ -159,7 +159,7 @@ An empty value for `xml:lang` attribute is ignored by this rule, as the applicab
 ```html
 <html>
 	<body>
-		<article data-rule-target xml:lang=""></article>
+		<article xml:lang=""></article>
 	</body>
 </html>
 ```

--- a/_rules/SC3-3-2+SC4-1-2-form-field-has-name.md
+++ b/_rules/SC3-3-2+SC4-1-2-form-field-has-name.md
@@ -53,7 +53,7 @@ Implicit role with implicit label.
 ```html
 <label>
   first name
-  <input data-rule-target/>
+  <input/>
 </label>
 ```
 
@@ -71,7 +71,7 @@ Implicit role with explicit label
 
 ```html
 <label for="country">Country</label>
-<select id="country" data-rule-target>
+<select id="country">
   <option></option>
 </select>
 ```
@@ -82,7 +82,7 @@ Implicit role with `aria-labelledby`.
 
 ```html
 <div id="country">Country</div>
-<textarea aria-labelledby="country" data-rule-target></textarea>
+<textarea aria-labelledby="country"></textarea>
 ```
 
 #### Passed example 5
@@ -134,7 +134,7 @@ Implicit label not supported on div elements.
 ```html
 <label>
   first name
-  <div role="textbox" data-rule-target></div>
+  <div role="textbox"></div>
 </label>
 ```
 
@@ -144,7 +144,7 @@ Explicit label not supported on div elements.
 
 ```html
 <label for="lastname">first name</label>
-<div role="textbox" id="lastname" data-rule-target></div>
+<div role="textbox" id="lastname"></div>
 ```
 
 ### Inapplicable 

--- a/_rules/SC4-1-2-aria-hidden-focus.md
+++ b/_rules/SC4-1-2-aria-hidden-focus.md
@@ -61,7 +61,7 @@ Content not focusable by default.
 Content hidden through CSS.
 
 ```html
-<div aria-hidden="true" data-rule-target>
+<div aria-hidden="true">
 	<a href="/" style="display:none">Link</a>
 </div>
 ```
@@ -71,7 +71,7 @@ Content hidden through CSS.
 Content made unfocusable through tabindex.
 
 ```html
-<div aria-hidden="true" data-rule-target>
+<div aria-hidden="true">
 	<button tabindex="-1">Some button</button>
 </div>
 ```
@@ -91,7 +91,7 @@ Content made unfocusable through disabled.
 Focusable off screen link.
 
 ```html
-<div aria-hidden="true" data-rule-target>
+<div aria-hidden="true">
 	<a href="/" style="position:absolute; top:-999em">Link</a>
 </div>
 ```
@@ -101,7 +101,7 @@ Focusable off screen link.
 Focusable form field, incorrectly disabled.
 
 ```html
-<div aria-hidden="true" data-rule-target>
+<div aria-hidden="true">
 	<input aria-disabled="true" />
 </div>
 ```
@@ -111,8 +111,8 @@ Focusable form field, incorrectly disabled.
 `aria-hidden=false` does not negate aria-hidden true.
 
 ```html
-<div aria-hidden="true" data-rule-target>
-    <div aria-hidden="false" data-rule-target>
+<div aria-hidden="true">
+    <div aria-hidden="false">
         <button tabindex="-1">Some button</button>
     </div>
 </div>
@@ -131,7 +131,7 @@ Focusable content through `tabindex`.
 Focusable summary element
 
 ```html
-<details aria-hidden="true" data-rule-target>
+<details aria-hidden="true">
     <summary>Some button</summary>
     <p>Some details</p>
 </details>
@@ -160,7 +160,7 @@ Ignore `aria-hidden` false.
 Incorrect value of `aria-hidden`.
 
 ```html
-<div aria-hidden="yes" data-rule-target>
+<div aria-hidden="yes">
 	<p>Some text</p>
 </div>
 ```

--- a/_rules/SC4-1-2-button-has-name.md
+++ b/_rules/SC4-1-2-button-has-name.md
@@ -106,7 +106,7 @@ Off screen elements should be tested.
     }
   </style>
   <body>
-    <button data-rule-target class='notInPage'>Save</button>
+    <button class='notInPage'>Save</button>
   </body>
 </html>
 ```
@@ -151,7 +151,7 @@ Off screen element with out an accessible name.
     }
   </style>
   <body>
-    <button data-rule-target class='notInPage' value='delete'></button>
+    <button class='notInPage' value='delete'></button>
   </body>
 </html>
 ```
@@ -180,7 +180,7 @@ Not visible in page and not included in the accessibility tree.
     }
   </style>
   <body>
-    <button data-rule-target class='notInPage' aria-hidden='true'>Confirm</button>
+    <button class='notInPage' aria-hidden='true'>Confirm</button>
   </body>
 </html>
 ```


### PR DESCRIPTION
All references to selectors `data-rule-target` in test cases of the rules have been removed.

Closes issue: NA