### PR TITLE
Fix links on "Iframe has accessible name"

### DIFF
--- a/_rules/SC4-1-2-iframe-has-name.md
+++ b/_rules/SC4-1-2-iframe-has-name.md
@@ -38,8 +38,8 @@ _There are no major accessibility support issues known for this rule._
 ## Background
 
 - [H64: Using the title attribute of the frame and iframe elements](http://www.w3.org/TR/WCAG20-TECHS/H64.html)
-- [Understanding Success Criterion 4.1.2 | Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/ensure-compat-rsv.html)
-- [Understanding Success Criterion 2.4.1 | Understanding WCAG 2.0](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-skip.html)
+- [Understanding Success Criterion 4.1.2](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)
+- [Understanding Success Criterion 2.4.1](https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html)
 - [User interface component](https://www.w3.org/TR/WCAG21/#dfn-user-interface-components)
 
 ## Test cases


### PR DESCRIPTION
Links in Background were broken due to use of pipe character. 
While fixing the links, I updated them to link to WCAG 2.1 Understanding documents instead of WCAG 2.0. 

Closes issue: none, but fixes bug found on https://auto-wcag.github.io/auto-wcag/rules/SC4-1-2-iframe-has-name.html

# How to Review And Approve
- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
