### PR TITLE
Added SC 2.4.9 to "Link has an accessible name"

### DIFF
--- a/_rules/SC2-4-4+2-4-9+4-1-2-link-has-name.md
+++ b/_rules/SC2-4-4+2-4-9+4-1-2-link-has-name.md
@@ -5,7 +5,8 @@ description: |
 
 success_criterion:
 - 4.1.2 # Name, Role, Value
-- 2.4.4
+- 2.4.4 # Link Purpose (In Context)
+- 2.4.9 # Link Purpose (Link Only)
 
 test_aspects: # Remove what is not applicable
 - DOM Tree


### PR DESCRIPTION
Added SC 2.4.9 Link Purpose (Link Only), since this is the stricter version of 2.4.4 Link Purpose (In Context) that was already listed as a requirement.

Closes issue: none

## Guidance for the PR (pull request) creator

# How to Review And Approve
- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
