### PR TITLE
Added heading/legend context to expectation of "descriptive labels"

### DIFF
--- a/_rules/SC2-4-6-descriptive-labels.md
+++ b/_rules/SC2-4-6-descriptive-labels.md
@@ -35,7 +35,7 @@ This rule applies to any HTML `label` element or other element referenced by `ar
 
 ### Expectation
 
-Each target element describes the purpose of the associated form field element.
+Each target element, together with it's programmatically associated heading or legend elements, describes the purpose of the associated form field element.
 
 **Note**: Labels do not need to be lengthy. A word, or even a single character, may suffice.
 
@@ -100,6 +100,27 @@ Label is included in accessibility tree, but not visible
 ```html
 <p id="label_fname" style="position: absolute; top: -9999px; left: -9999px;">First name:</p>
 <input aria-labelledby="label_fname" type="text" name="fname"/>
+```
+
+#### Passed example 6
+
+The label alone is not enough to describe the purpose of the field, but together with it's context it is.
+
+```html
+<fieldset>
+  <legend>
+    Shipping adress
+  </legend>
+  <label for="shippingfname">First name:</label>
+  <input id="shippingfname" type="text" name="fname"/>
+</fieldset>
+<fieldset>
+  <legend>
+    Billing adress
+  </legend>
+  <label for="billingfname">First name:</label>
+  <input id="billingfname" type="text" name="fname"/>
+</fieldset>
 ```
 
 ### Failed


### PR DESCRIPTION
Heading and Legend elements can now add context to the label to better describe the goal of the input field.

<< Describe the changes >>

Closes issue: #423 
## Guidance for the PR (pull request) creator

**When creating PR:**
- [ ] Make sure you requesting to **pull a issue/feature/bugfix branch** (right side) to the master branch (left side).

**After creating PR:**
- [ ] Add yourself (and co-authors) as "Assignees" for PR
- [ ] Add label to indicate if it's a `Rule`, `Definition` or `Chore` (more to the administrative side)
- [ ] Add relevant project (e.g. "Q3 2018 Status") to PR
- [ ] OPTIONAL: If you want anyone in particular to review your pull request, assign them as "Reviewers".
- [ ] Close the issue that the PR resolves (and make sure the issue is referenced in the top of this comment)

# How to Review And Approve
- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines. 
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
