### PR TITLE
Update ARIA value valid rule mapping to ARIA 1.2

### DIFF
--- a/_rules/aria-state-or-property-valid-value-6a7281.md
+++ b/_rules/aria-state-or-property-valid-value-6a7281.md
@@ -5,8 +5,8 @@ rule_type: atomic
 description: |
   This rule checks that each ARIA state or property has a valid value type.
 accessibility_requirements:
-  aria11:state_prop_values:
-    title: ARIA 1.1, 6.3 Values for States and Properties
+  aria12:propcharacteristic_value:
+    title: ARIA 1.1, 6.2.4 Value (Characteristics of States and Properties)
     forConformance: true
     failed: not satisfied
     passed: satisfied

--- a/_rules/aria-state-or-property-valid-value-6a7281.md
+++ b/_rules/aria-state-or-property-valid-value-6a7281.md
@@ -6,7 +6,7 @@ description: |
   This rule checks that each ARIA state or property has a valid value type.
 accessibility_requirements:
   aria12:propcharacteristic_value:
-    title: ARIA 1.1, 6.2.4 Value (Characteristics of States and Properties)
+    title: ARIA 1.2, 6.2.4 Value (Characteristics of States and Properties)
     forConformance: true
     failed: not satisfied
     passed: satisfied


### PR DESCRIPTION
Section 6.3 was completely removed from WAI-ARIA 1.2, so I had to map it to a different section. This one seemed most appropriate.

Part of issue #1867

---

This is one part of migrating ACT Rules over to WAI-ARIA 1.2. We'll have all WAI-ARIA 1.2 PRs go to the wai-aria 1.2 branch, which we'll merge into the develop branch once everything is ready. This lets us chunk up the work while ensuring the upgrade to WAI-ARIA 1.2 happens all at once.

The final WAI-ARIA 1.2 PR will be a 2 week call for review. Everything going into that branch will require the usual 3 approvals, but will not be sent out as call for review.

Need for Call for Review: none

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
