### PR TITLE
Adds prohibited attributes expectation to rule 5c01ea

### DIFF
--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -183,6 +183,14 @@ The `aria-orientation` property may not be used on `audio` element, nor it can b
 <audio src="/test-assets/moon-audio/moon-speech.mp3" controls aria-orientation="horizontal"></audio>
 ```
 
+#### Failed Example 3
+
+The `aria-label` property may not be used on a `generic` element as it [prohibited from being named](https://www.w3.org/TR/wai-aria-1.2/#namefromprohibited).
+
+```html
+<div aria-label="Bananas"></div>
+```
+
 ### Inapplicable
 
 #### Inapplicable Example 1

--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -42,6 +42,8 @@ For each test target, one of the following is true:
 - **semantic Role**: the test target is an [inherited][], [supported][], or [required][] [state][] or [property][] of the [semantic role][] of the element on which the test target is specified; or
 - **language feature**: the test target is specified on an [HTML element][namespaced element] and is allowed on that element. Which ARIA states or properties may be used on which element is described in [ARIA in HTML](https://w3c.github.io/html-aria/).
 
+For each test target there are no prohibited attributes for the target's role.
+
 ## Assumptions
 
 _There are currently no assumptions_

--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -34,7 +34,7 @@ acknowledgments:
 
 This rule applies to any [WAI-ARIA state or property][] that is specified on an [HTML or SVG element][namespaced element] that is [included in the accessibility tree][].
 
-## Expectation
+## Expectation 1
 
 For each test target, one of the following is true:
 
@@ -42,7 +42,9 @@ For each test target, one of the following is true:
 - **semantic Role**: the test target is an [inherited][], [supported][], or [required][] [state][] or [property][] of the [semantic role][] of the element on which the test target is specified; or
 - **language feature**: the test target is specified on an [HTML element][namespaced element] and is allowed on that element. Which ARIA states or properties may be used on which element is described in [ARIA in HTML](https://w3c.github.io/html-aria/).
 
-For each test target there are no prohibited attributes for the target's role.
+## Expectation 2
+
+Each test target is not prohibited on the role of the element on which it is specified.
 
 ## Assumptions
 

--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -44,7 +44,7 @@ For each test target, one of the following is true:
 
 ## Expectation 2
 
-Each test target is not prohibited on the role of the element on which it is specified.
+Each test target is not [prohibited](https://www.w3.org/TR/wai-aria-1.2/#state_property_processing) on the role of the element on which it is specified.
 
 ## Assumptions
 

--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -187,7 +187,7 @@ The `aria-orientation` property may not be used on `audio` element, nor it can b
 
 #### Failed Example 3
 
-The `aria-label` property may not be used on a `generic` element as it [prohibited from being named](https://www.w3.org/TR/wai-aria-1.2/#namefromprohibited).
+The `aria-label` property may not be used on an element with a `generic` role as it is [prohibited from being named](https://www.w3.org/TR/wai-aria-1.2/#namefromprohibited).
 
 ```html
 <div aria-label="Bananas"></div>

--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -44,7 +44,7 @@ For each test target, one of the following is true:
 
 ## Expectation 2
 
-Each test target is not [prohibited](https://www.w3.org/TR/wai-aria-1.2/#state_property_processing) on the [semantic role][] of the element on which it is specified.
+Each test target is not [prohibited][] on the [semantic role][] of the element on which it is specified.
 
 ## Assumptions
 
@@ -187,7 +187,7 @@ The `aria-orientation` property may not be used on `audio` element, nor it can b
 
 #### Failed Example 3
 
-The `aria-label` property may not be used on an element with a `generic` role as it is [prohibited from being named](https://www.w3.org/TR/wai-aria-1.2/#namefromprohibited).
+The `aria-label` property is [prohibited][] for an element with a `generic` role.
 
 ```html
 <div aria-label="Bananas"></div>
@@ -226,3 +226,4 @@ This `div` element is not [included in the accessibility tree][], hence its [WAI
 [supported]: https://www.w3.org/TR/wai-aria/#supportedState 'Definition of Supported ARIA States and Properties'
 [wai-aria state or property]: https://www.w3.org/TR/wai-aria-1.1/#state_prop_def 'Definition of ARIA States and Properties'
 [namespaced element]: #namespaced-element
+[prohibited]: https://www.w3.org/TR/wai-aria-1.2/#prohibitedattributes 'WAI-ARIA 1.2 Definition of Prohibited States and Properties'

--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -44,7 +44,7 @@ For each test target, one of the following is true:
 
 ## Expectation 2
 
-Each test target is not [prohibited](https://www.w3.org/TR/wai-aria-1.2/#state_property_processing) on the role of the element on which it is specified.
+Each test target is not [prohibited](https://www.w3.org/TR/wai-aria-1.2/#state_property_processing) on the [semantic role][] of the element on which it is specified.
 
 ## Assumptions
 


### PR DESCRIPTION
This patch adds a second expectation regarding usage of prohibited attributes for a given role. Based on [ARIA 1.2's statement](https://www.w3.org/TR/wai-aria-1.2/#state_property_processing):

> Global states and properties are supported on any element in the host language. However, authors MUST only use non-global states and properties on elements with a role supporting the state or property; either defined as an explicit WAI-ARIA role, or as defined by the host language implicit WAI-ARIA semantic matching an appropriate WAI-ARIA role.

Closes issue(s):

- closes #1535
