### PR TITLE
Update ARIA required properties rule to WAI-ARIA 1.2

### DIFF
--- a/_rules/role-required-states-and-properties-4e8ab6.md
+++ b/_rules/role-required-states-and-properties-4e8ab6.md
@@ -222,6 +222,6 @@ This `combobox` is not [included in the accessibility tree][] due to its styling
 [included in the accessibility tree]: #included-in-the-accessibility-tree 'Definition of Included in The Accessibility Tree'
 [wai-aria required states and properties]: https://www.w3.org/TR/wai-aria-1.2/#requiredState
 [wai-aria implicit value for role]: https://www.w3.org/TR/wai-aria-1.2/#implictValueForRole
-[wai-aria 1.1]: https://www.w3.org/TR/wai-aria-1.1/
 [wai-aria 1.2]: https://www.w3.org/TR/wai-aria-1.2/
 [html or svg element]: #namespaced-element
+[focusable]: #focusable

--- a/_rules/role-required-states-and-properties-4e8ab6.md
+++ b/_rules/role-required-states-and-properties-4e8ab6.md
@@ -89,7 +89,7 @@ This `scrollbar` has the required properties `aria-controls` and `aria-valuenow`
 <main id="content"></main>
 ```
 
-### Passed Example 4
+#### Passed Example 4
 
 These `option` nodes do not need the required `aria-selected` property because it has a default value of `false`.
 
@@ -101,7 +101,7 @@ These `option` nodes do not need the required `aria-selected` property because i
 </ul>
 ```
 
-### Passed Example 5
+#### Passed Example 5
 
 This `separator` is not a `widget` because it is not [focusable][]. The `separator` role only requires the `aria-valuenow` property when the element is focusable.
 

--- a/_rules/role-required-states-and-properties-4e8ab6.md
+++ b/_rules/role-required-states-and-properties-4e8ab6.md
@@ -180,7 +180,7 @@ This `combobox` does not have the required `aria-expanded` property. Prior to [W
 
 #### Failed Example 6
 
-This `combobox` uses `aria-owns` where it should use `aria-controls` property. This property is required as of [WAI-ARIA 1.1][].
+This `combobox` uses `aria-owns` instead of using the required `aria-controls` property.
 
 ```html
 <label for="tag_combo">Tag</label>

--- a/_rules/role-required-states-and-properties-4e8ab6.md
+++ b/_rules/role-required-states-and-properties-4e8ab6.md
@@ -15,6 +15,11 @@ accessibility_requirements:
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
+  aria12:requiredState: # 5.2.2 Required States and Properties
+    forConformance: true
+    failed: not satisfied
+    passed: satisfied
+    inapplicable: satisfied
 input_aspects:
   - DOM Tree
 acknowledgments:
@@ -31,8 +36,6 @@ This rule applies to any [HTML or SVG element][] that is [included in the access
 ## Expectation
 
 For each test target, the [WAI-ARIA required states and properties][] for the role are set and not empty (`""`), unless the state or property has a default value listed under [WAI-ARIA implicit value for role][].
-
-**Note**: In [WAI-ARIA 1.2][], required states and properties will no longer have a default value.
 
 ## Assumptions
 
@@ -51,7 +54,7 @@ This rule relies on browsers and assistive technologies to support leaving out [
 ### Bibliography
 
 - [ARIA5: Using WAI-ARIA state and property attributes to expose the state of a user interface component](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA5)
-- [WAI-ARIA required states and properties](https://www.w3.org/TR/wai-aria-1.1/#requiredState)
+- [WAI-ARIA required states and properties](https://www.w3.org/TR/wai-aria-1.2/#requiredState)
 - [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt)
 
 ## Test Cases
@@ -60,13 +63,24 @@ This rule relies on browsers and assistive technologies to support leaving out [
 
 #### Passed Example 1
 
-This `checkbox` has the required property `aria-checked`.
+This `heading` has the required `aria-level` property.
 
 ```html
-<div role="checkbox" aria-checked="false"></div>
+<div role="heading" aria-level="1">
+	My First Heading
+</div>
 ```
 
 #### Passed Example 2
+
+This `checkbox` has the required `aria-checked` property.
+
+```html
+<div role="checkbox" aria-checked="false"></div>
+<div id="label">Check me</div>
+```
+
+#### Passed Example 3
 
 This `scrollbar` has the required properties `aria-controls` and `aria-valuenow`. `aria-valuemin` has a default value of 0 and `aria-valuemax` of 100.
 
@@ -75,32 +89,106 @@ This `scrollbar` has the required properties `aria-controls` and `aria-valuenow`
 <main id="content"></main>
 ```
 
-#### Passed Example 3
+### Passed Example 4
 
-This `combobox` has required properties `aria-controls` and `aria-expanded`. `aria-controls` references an element that does not exist, but may be added to the page when expanded.
+These `option` nodes do not need the required `aria-selected` property because it has a default value of `false`.
 
 ```html
-<div role="combobox" aria-controls="someElementId" aria-expanded="false"></div>
+<div id="label">Tags</div>
+<ul role="listbox" aria-labelledby="label">
+	<li role="option">Zebra</li>
+	<li role="option">Zoom</li>
+</ul>
+```
+
+### Passed Example 5
+
+This `separator` is not a `widget` because it is not [focusable][]. The `separator` role only requires the `aria-valuenow` property when the element is focusable.
+
+```html
+<p>My first HTML</p>
+<div role="separator"></div>
+<p>My last HTML</p>
+```
+
+#### Passed Example 6
+
+This `combobox` has the required properties `aria-controls` and `aria-expanded`.
+
+```html
+<label for="tag_combo">Tag</label>
+<input type="text" id="tag_combo" role="combobox" aria-expanded="true" aria-controls="popup_listbox" />
+<ul role="listbox" id="popup_listbox">
+	<li role="option">Zebra</li>
+	<li role="option" id="selected_option">Zoom</li>
+</ul>
 ```
 
 ### Failed
 
 #### Failed Example 1
 
-This `combobox` is missing the required `aria-controls` property.
-
-**Note**: In [WAI-ARIA 1.2][], `combobox` will also require `aria-expanded`.
+This `heading` does not have the required `aria-level` property. Prior to [WAI-ARIA 1.2][] the `heading` role had an implicit default `aria-level` value of `2`. As of WAI-ARIA 1.2 this property must be explicitly set.
 
 ```html
-<div role="combobox" aria-expanded="true"></div>
+<div role="heading">
+	My First Heading
+</div>
 ```
 
 #### Failed Example 2
 
-This `combobox` has an empty value for the required `aria-controls` property.
+This `switch` does not have the required `aria-checked` property. Prior to [WAI-ARIA 1.2][] the `switch` role had an implicit default `aria-checked` value of `false`. As of WAI-ARIA 1.2 this property must be explicitly set.
 
 ```html
-<div role="combobox" aria-controls="" aria-expanded="true"></div>
+<div role="switch">
+	Toggle me
+</div>
+```
+
+#### Failed Example 3
+
+This `checkbox` does not have the required property `aria-checked`. Prior to [WAI-ARIA 1.2][] the `checkbox` had an implicit default `aria-checked` value of `false`. As of WAI-ARIA 1.2 this property must be explicitly set.
+
+```html
+<div role="checkbox" aria-labelledby="label"></div>
+<div id="label">Check me</div>
+```
+
+#### Failed Example 4
+
+This `separator` does not have the required `aria-valuenow` property. This is required because the `separator` is [focusable][], which makes it a `widget`.
+
+```html
+<p>My first HTML</p>
+<div role="separator" tabindex="0"></div>
+<p>My last HTML</p>
+```
+
+#### Failed Example 5
+
+This `combobox` does not have the required `aria-expanded` property. Prior to [WAI-ARIA 1.2][] the `combobox` had an implicit default `aria-expanded` value of `false`. As of WAI-ARIA 1.2 this property must be explicitly set.
+
+```html
+<label for="tag_combo">Tag</label>
+<input type="text" id="tag_combo" role="combobox" aria-controls="popup_listbox" />
+<ul role="listbox" id="popup_listbox">
+	<li role="option">Zebra</li>
+	<li role="option" id="selected_option">Zoom</li>
+</ul>
+```
+
+#### Failed Example 6
+
+This `combobox` uses `aria-owns` where it should use `aria-controls` property. This property is required as of [WAI-ARIA 1.1][].
+
+```html
+<label for="tag_combo">Tag</label>
+<input type="text" id="tag_combo" role="combobox" aria-expanded="true" aria-owns="popup_listbox" />
+<ul role="listbox" id="popup_listbox">
+	<li role="option">Zebra</li>
+	<li role="option" id="selected_option">Zoom</li>
+</ul>
 ```
 
 ### Inapplicable
@@ -115,7 +203,7 @@ This `div` does not have a [semantic role](#semantic-role).
 
 #### Inapplicable Example 2
 
-This `checkbox` has an [implicit semantic role](#implicit-role) that is identical to the [explicit semantic role](#explicit-role).
+This `checkbox` has an [implicit semantic role](#implicit-role) that is identical to the [explicit semantic role](#explicit-role). This allows native HTML `checked` state to apply.
 
 ```html
 <input type="checkbox" role="checkbox" />
@@ -132,7 +220,8 @@ This `combobox` is not [included in the accessibility tree][] due to its styling
 [explicit semantic role]: #explicit-role 'Definition of explicit semantic role'
 [implicit semantic role]: #implicit-role 'Definition of implicit semantic role'
 [included in the accessibility tree]: #included-in-the-accessibility-tree 'Definition of Included in The Accessibility Tree'
-[wai-aria required states and properties]: https://www.w3.org/TR/wai-aria-1.1/#requiredState
-[wai-aria implicit value for role]: https://www.w3.org/TR/wai-aria-1.1/#implictValueForRole
+[wai-aria required states and properties]: https://www.w3.org/TR/wai-aria-1.2/#requiredState
+[wai-aria implicit value for role]: https://www.w3.org/TR/wai-aria-1.2/#implictValueForRole
+[wai-aria 1.1]: https://www.w3.org/TR/wai-aria-1.1/
 [wai-aria 1.2]: https://www.w3.org/TR/wai-aria-1.2/
 [html or svg element]: #namespaced-element


### PR DESCRIPTION
- Add several new related to properties that in ARIA 1.2 no longer have a default value
- Add an example for the separator, which has a required prop only if it is focusable
- Improve the combobox examples, borrowing code from the WAI-ARIA spec itself
- Add accessible names to elements that require one

Closes #1282, closes #1373

---

This is one part of migrating ACT Rules over to WAI-ARIA 1.2. We'll have all WAI-ARIA 1.2 PRs go to the wai-aria 1.2 branch, which we'll merge into the develop branch once everything is ready. This lets us chunk up the work while ensuring the upgrade to WAI-ARIA 1.2 happens all at once.

The final WAI-ARIA 1.2 PR will be a 2 week call for review. Everything going into that branch will require the usual 3 approvals, but will not be sent out as call for review.

Need for Call for Review: none

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
