### PR TITLE
Add secondary requirements to rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ yarn.lock
 
 # Ignore JetBrains IDE file
 .idea
+
+# Tmp build directory
+wcag-act-rules-tmp/

--- a/_rules/image-no-text-0va7u6.md
+++ b/_rules/image-no-text-0va7u6.md
@@ -10,8 +10,9 @@ accessibility_requirements:
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
-  wcag20:1.4.9: # Images of Text (No Exception) (AA)
+  wcag20:1.4.9: # Images of Text (No Exception) (AAA)
     forConformance: true
+    secondary: true
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed

--- a/_rules/link-in-context-descriptive-5effbb.md
+++ b/_rules/link-in-context-descriptive-5effbb.md
@@ -5,13 +5,14 @@ rule_type: atomic
 description: |
   This rule checks that the accessible name of a link together with its context describes its purpose.
 accessibility_requirements:
-  wcag20:2.4.4: # Link Purpose (In Context)
+  wcag20:2.4.4: # Link Purpose (In Context) (A)
     forConformance: true
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
-  wcag20:2.4.9: # Link Purpose (Link Only)
+  wcag20:2.4.9: # Link Purpose (Link Only) (AAA)
     forConformance: true
+    secondary: true
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed

--- a/_rules/link-non-empty-accessible-name-c487ae.md
+++ b/_rules/link-non-empty-accessible-name-c487ae.md
@@ -17,6 +17,7 @@ accessibility_requirements:
     inapplicable: further testing needed
   wcag20:2.4.9: # Link Purpose (Link Only) (AAA)
     forConformance: true
+    secondary: true
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed

--- a/_rules/links-with-identical-names-and-context-serve-equivalent-purpose-fd3a94.md
+++ b/_rules/links-with-identical-names-and-context-serve-equivalent-purpose-fd3a94.md
@@ -12,6 +12,7 @@ accessibility_requirements:
     inapplicable: further testing needed
   wcag20:2.4.9: # Link Purpose (Link Only) (AAA)
     forConformance: true
+    secondary: true
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed

--- a/_rules/meta-refresh-no-delay-bc659a.md
+++ b/_rules/meta-refresh-no-delay-bc659a.md
@@ -12,11 +12,13 @@ accessibility_requirements:
     inapplicable: further testing needed
   wcag20:2.2.4: # Interruptions (AAA)
     forConformance: true
+    secondary: true
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
   wcag20:3.2.5: # Change on Request (AAA)
     forConformance: true
+    secondary: true
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed

--- a/_rules/scrollable-element-keyboard-accessible-0ssw9k.md
+++ b/_rules/scrollable-element-keyboard-accessible-0ssw9k.md
@@ -12,6 +12,7 @@ accessibility_requirements:
     inapplicable: further testing needed
   wcag20:2.1.3: # Keyboard (No Exceptions) (AAA)
     forConformance: true
+    secondary: true
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed

--- a/_rules/text-contrast-afw4f7.md
+++ b/_rules/text-contrast-afw4f7.md
@@ -5,13 +5,14 @@ rule_type: atomic
 description: |
   This rule checks that the highest possible contrast of every text character with its background meets the minimal contrast requirement.
 accessibility_requirements:
-  wcag20:1.4.3: # Contrast (Minimum)
+  wcag20:1.4.3: # Contrast (Minimum) (AA)
     forConformance: true
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
-  wcag20:1.4.6: # Contrast (Enhanced)
+  wcag20:1.4.6: # Contrast (Enhanced) (AAA)
     forConformance: true
+    secondary: true
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed

--- a/_rules/video-alternative-for-visual-c5a4ea.md
+++ b/_rules/video-alternative-for-visual-c5a4ea.md
@@ -10,13 +10,15 @@ accessibility_requirements:
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
-  wcag20:1.2.5: # Audio Description (Prerecorded) (AAA)
+  wcag20:1.2.5: # Audio Description (Prerecorded) (AA)
     forConformance: true
+    secondary: true
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
   wcag20:1.2.8: # Media Alternative (Prerecorded) (AAA)
     forConformance: true
+    secondary: true
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1882,7 +1882,7 @@
 		},
 		"node_modules/act-tools": {
 			"version": "1.0.0",
-			"resolved": "git+ssh://git@github.com/act-rules/act-tools.git#9ead9ecd14b0b8e12c3bf15cb8ad0cd0a32dd8e7",
+			"resolved": "git+ssh://git@github.com/act-rules/act-tools.git#77377972c5bc295215cf0e5a0e0b222d151826a5",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -13407,7 +13407,7 @@
 			"dev": true
 		},
 		"act-tools": {
-			"version": "git+ssh://git@github.com/act-rules/act-tools.git#9ead9ecd14b0b8e12c3bf15cb8ad0cd0a32dd8e7",
+			"version": "git+ssh://git@github.com/act-rules/act-tools.git#77377972c5bc295215cf0e5a0e0b222d151826a5",
 			"dev": true,
 			"from": "act-tools@github:act-rules/act-tools#main",
 			"requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1882,7 +1882,7 @@
 		},
 		"node_modules/act-tools": {
 			"version": "1.0.0",
-			"resolved": "git+ssh://git@github.com/act-rules/act-tools.git#d55fc17be5489f2e0776fb8aa474768a375c0150",
+			"resolved": "git+ssh://git@github.com/act-rules/act-tools.git#9ead9ecd14b0b8e12c3bf15cb8ad0cd0a32dd8e7",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -13407,7 +13407,7 @@
 			"dev": true
 		},
 		"act-tools": {
-			"version": "git+ssh://git@github.com/act-rules/act-tools.git#d55fc17be5489f2e0776fb8aa474768a375c0150",
+			"version": "git+ssh://git@github.com/act-rules/act-tools.git#9ead9ecd14b0b8e12c3bf15cb8ad0cd0a32dd8e7",
 			"dev": true,
 			"from": "act-tools@github:act-rules/act-tools#main",
 			"requires": {


### PR DESCRIPTION
This pull request makes it so that reporting AAA success criteria as failed on rules for AA becomes optional for implementors. I.e. implementors may fail them, but aren't required to.

Anticipating work on https://github.com/w3c/wcag-act/pull/531/, this pull request lists a number of success criteria as "secondary". These are criteria that fail when the rule fails, but don't necessarily pass when the rule passed. 


This PR is jumping the gun a little on this, but I think this is important to get done because it is causing problems for at least three of the implementors currently. Their implementations are reported as partially consistent for not failing a AAA success criterion, even though the implementor does not support AAA to begin with.

Closes issue(s): https://github.com/w3c/wcag-act-rules/issues/134


Need for Call for Review: 1 week

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
