### PR TITLE
meta refresh (no exceptions) examples should not fail SC 2.2.1

### DIFF
--- a/_rules/meta-refresh-no-delay-no-exception-bisz58.md
+++ b/_rules/meta-refresh-no-delay-no-exception-bisz58.md
@@ -129,16 +129,6 @@ The first `meta` element is not valid (because of the colon instead of a semi-co
 </head>
 ```
 
-#### Failed Example 4
-
-This `meta` element redirects the user after 20 hours.
-
-```html
-<head>
-	<meta http-equiv="refresh" content="72001; http://example.com" />
-</head>
-```
-
 ### Inapplicable
 
 #### Inapplicable Example 1

--- a/_rules/meta-refresh-no-delay-no-exception-bisz58.md
+++ b/_rules/meta-refresh-no-delay-no-exception-bisz58.md
@@ -92,7 +92,7 @@ The first valid `meta` element redirects immediately.
 ```html
 <head>
 	<meta http-equiv="refresh" content="0; https://w3.org" />
-	<meta http-equiv="refresh" content="5; https://w3.org" />
+	<meta http-equiv="refresh" content="72001; https://w3.org" />
 </head>
 ```
 
@@ -100,32 +100,32 @@ The first valid `meta` element redirects immediately.
 
 #### Failed Example 1
 
-This `meta` element refreshes the page after 30 seconds.
+This `meta` element refreshes the page after 20 hours.
 
 ```html
 <head>
-	<meta http-equiv="refresh" content="30" />
+	<meta http-equiv="refresh" content="72001" />
 </head>
 ```
 
 #### Failed Example 2
 
-This `meta` element redirects the user after 30 seconds.
+This `meta` element redirects the user after 20 hours.
 
 ```html
 <head>
-	<meta http-equiv="refresh" content="30; URL='https://w3.org'" />
+	<meta http-equiv="refresh" content="72001; URL='https://w3.org'" />
 </head>
 ```
 
 #### Failed Example 3
 
-The first `meta` element is not valid (because of the colon instead of a semi-colon in the `content` attribute), the second one redirects after 5 seconds.
+The first `meta` element is not valid (because of the colon instead of a semi-colon in the `content` attribute), the second one redirects after 20 hours.
 
 ```html
 <head>
 	<meta http-equiv="refresh" content="0: https://w3.org" />
-	<meta http-equiv="refresh" content="5; https://w3.org" />
+	<meta http-equiv="refresh" content="72001; https://w3.org" />
 </head>
 ```
 
@@ -157,7 +157,7 @@ This `meta` element has no `http-equiv="refresh"` attribute.
 
 ```html
 <head>
-	<meta content="30" />
+	<meta content="72001" />
 </head>
 ```
 
@@ -187,7 +187,7 @@ This `meta` element has an invalid `content` attribute, and is therefore inappli
 
 ```html
 <head>
-	<meta http-equiv="refresh" content="; 30" />
+	<meta http-equiv="refresh" content="; 72001" />
 </head>
 ```
 
@@ -207,7 +207,7 @@ This `meta` element has an invalid `content` attribute, and is therefore inappli
 
 ```html
 <head>
-	<meta http-equiv="refresh" content="+5; http://w3.org" />
+	<meta http-equiv="refresh" content="+72001; http://w3.org" />
 </head>
 ```
 


### PR DESCRIPTION
/me Chair hat off, product owner hat on

I'm having difficulties mapping to the Meta element refresh (no exceptions) ACT rule. Axe-core has two rules on meta elements. One that tests for failures of SC 2.2.1, and one that tests for failures of SC 2.2.4 that are not failures of SC 2.2.1. I.e. two axe-core rules combined cover all of this single ACT rule.

The problem is that this "no exceptions" ACT rule has examples that also fail SC 2.2.1. When axe-core reports those as failures of both SC 2.2.1 and 2.2.4, that implementation ends up as partially consistent, because SC 2.2.1 isn't listed in the accessibility requirements.

I think there are two solutions for it:
1. Ensure the failed examples don't fail SC 2.2.1; or
2. Add SC 2.2.1 as a secondary requirement

I noticed we don't have this problem on color contrast (enhanced) because all its failed examples pass level AA. As a quick solve, I think this will work.

We'll need a broader conversation about which option we'll want for scenarios like this, as part of discussing secondary requirements. My guess is we'll end up with option 2, but I don't think we're ready to commit to that just yet, and I since this is a priority issue, I don't think we should wait.


Need for Call for Review: 1 week

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
