### PR TITLE
Add GitHub script to set rules to approved

### DIFF
--- a/.github/scripts/approve-rule.mjs
+++ b/.github/scripts/approve-rule.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env zx
+import 'zx/globals';
+import assert from 'assert';
+import moment from 'moment';
+
+import {
+  config,
+  cloneWcagActRules,
+  createOrCheckoutBranch,
+  commitAndPush
+} from './commons.mjs';
+
+const w3cDataFormat = 'D MMMM YYYY';
+const isoDateFormat = 'YYYY-MM-DD';
+
+assert(typeof argv.ruleId === 'string', 'Expected --ruleId to be set');
+assert(argv.ruleId.length === 6, 'Expected --ruleId to be 6 characters long');
+assert(typeof argv.branch === 'string', 'Expected --branch to be set');
+
+if (!argv['skip-clone']) {
+  await cloneWcagActRules(config);
+}
+
+await createOrCheckoutBranch(config, argv.branch);
+await generateApprovedRulePages(config, argv.ruleId);
+await updateRuleVersionsYaml(config, argv.ruleId);
+await approveTestCaseJson(config, argv.ruleId);
+await commitAndPush(config, `Set ${argv.ruleId} to approved`);
+
+async function generateApprovedRulePages({ tmpDir, rulesDir, glossaryDir }, ruleId) {
+  await $`node ./node_modules/act-tools/dist/cli/rule-transform.js \
+  --rulesDir "${rulesDir}" \
+  --glossaryDir "${glossaryDir}" \
+  --outDir "${tmpDir}" \
+  --ruleIds "${ruleId}"
+  `;
+}
+
+async function updateRuleVersionsYaml({ tmpDir }, ruleId) {
+  const ruleVersionPath = `${tmpDir}_data/wcag-act-rules/rule-versions.yml`;
+  let ruleVersionsStr = fs.readFileSync(ruleVersionPath, 'utf8');
+  const ruleVersions = YAML.parse(ruleVersionsStr);
+  assert(
+    ruleVersions[ruleId] === undefined,
+    `RuleID ${ruleId} should not exists in rule-versions.yml. Was this rule approved before?`
+  );
+
+  const proposedText = fs.readFileSync(`${tmpDir}content/rules/${ruleId}/proposed.md`, 'utf8');
+  const proposedData = proposedText.match(/last_modified:\s+(.*)/)?.[1]
+  assert(proposedData, `Unable to find last_modified data in ${ruleId}/proposed.md`);
+
+  ruleVersions[ruleId] = [{
+    file: 'proposed.md',
+    url: `${ruleId}/proposed/`,
+    w3cDate: proposedData,
+    isoDate: moment(proposedData, w3cDataFormat).format(isoDateFormat)
+  }, {
+    file: 'index.md',
+    url: `${ruleId}/`,
+    w3cDate: moment().format(w3cDataFormat),
+    isoDate: moment().format(isoDateFormat)
+  }]
+  
+  ruleVersionsStr = YAML.stringify(ruleVersions);
+  fs.writeFileSync(ruleVersionPath, ruleVersionsStr, 'utf8');
+  console.log(`Added ${ruleId} to rule-versions.yml`);
+}
+
+async function approveTestCaseJson({ tmpDir }, ruleId) {
+  let testCaseCount = 0;
+  const testCaseJsonPath = `${tmpDir}content-assets/wcag-act-rules/testcases.json`;
+  const testCaseJson = JSON.parse(fs.readFileSync(testCaseJsonPath, 'utf8'));
+  testCaseJson.testcases.forEach((testCase, index) => {
+    if (testCase.ruleId === ruleId) {
+      // Override rather than update so that `approved` isn't at the bottom
+      testCaseJson.testcases[index] = { ruleId, approved: true, ...testCase }
+      testCaseCount++
+    }
+  });
+  console.log(`Set ${testCaseCount} test cases of rule ${ruleId} to be approved in testcases.json`);
+  fs.writeFileSync(testCaseJsonPath, JSON.stringify(testCaseJson, null, 2), 'utf8');
+}

--- a/.github/scripts/commons.mjs
+++ b/.github/scripts/commons.mjs
@@ -1,0 +1,52 @@
+import 'zx/globals';
+import assert from 'assert';
+
+export const config = {
+  tmpDir: `./wcag-act-rules-tmp/`,
+  rulesDir: `./_rules/`,
+  glossaryDir: `./pages/glossary/`,
+  testAssetsDir: `./test-assets/`,
+}
+
+export async function cloneWcagActRules({ tmpDir }) {
+  await $`rm -rf ${tmpDir}`;
+  await $`git clone \
+    --no-single-branch \
+    --branch main \
+    https://github.com/w3c/wcag-act-rules.git ${tmpDir} \
+    --depth 1
+  `;
+}
+
+export async function createOrCheckoutBranch({ tmpDir }, branchName) {
+  assert(branchName, 'branchName must be defined');
+  cd(tmpDir);
+  try {
+    await $`git checkout ${branchName}`;
+  } catch {
+    await $`git checkout -b ${branchName}`;
+  } finally {
+    cd(`../`);
+  }
+}
+
+export async function commitAndPush({ tmpDir }, commitMessage) {
+  cd(tmpDir);
+  try {
+    const diff = (await $`git diff --name-status`).stdout;
+    if (diff.trim().length === 0) {
+      console.log('No changes detected, skipping git commit')
+      return;
+    }
+    await $`git add .`;
+    await $`git commit -m ${commitMessage}`;
+    try {
+      await $`git push`;
+    } catch {
+      const branchName = (await $`git branch --show-current`);
+      await $`git push --set-upstream origin ${branchName}`;
+    }
+  } finally {
+    cd(`../`);
+  }
+}

--- a/.github/scripts/wai-build.mjs
+++ b/.github/scripts/wai-build.mjs
@@ -1,27 +1,12 @@
 #!/usr/bin/env zx
 import 'zx/globals';
-
-const config = {
-  tmpDir: `./wcag-act-rules-tmp/`,
-  rulesDir: `./_rules/`,
-  glossaryDir: `./pages/glossary/`,
-  testAssetsDir: `./test-assets/`,
-}
+import { config, cloneWcagActRules, commitAndPush } from './commons.mjs'
 
 await cloneWcagActRules(config);
 await generateProposedRulePages(config);
 await generateTestCases(config);
-await commitAndPush(config);
-
-async function cloneWcagActRules({ tmpDir }) {
-  await $`rm -rf ${tmpDir}`;
-  await $`git clone \
-    --single-branch \
-    --branch main \
-    https://github.com/w3c/wcag-act-rules.git ${tmpDir} \
-    --depth 1
-  `;
-}
+const commitMessage = (await $`git log -1 --pretty=%B`).stdout;
+await commitAndPush(config, commitMessage);
 
 async function generateProposedRulePages({ tmpDir, rulesDir, glossaryDir }) {
   await $`node ./node_modules/act-tools/dist/cli/rule-transform.js \
@@ -39,21 +24,4 @@ async function generateTestCases({ tmpDir, rulesDir, testAssetsDir }) {
     --outDir "${tmpDir}" \
     --proposed
   `;
-}
-
-async function commitAndPush({ tmpDir }) {
-  const commitMessage = (await $`git log -1 --pretty=%B`).stdout
-  cd(tmpDir);
-  try {
-    const diff = (await $`git diff --name-status`).stdout;
-    if (diff.trim().length === 0) {
-      console.log('No changes detected, skipping git commit')
-      return;
-    }
-    await $`git add .`;
-    await $`git commit -m ${commitMessage}`;
-    await $`git push`;
-  } finally {
-    cd(`../`);
-  }
 }

--- a/.github/workflows/approve-rule.yml
+++ b/.github/workflows/approve-rule.yml
@@ -1,0 +1,42 @@
+# Sets a rule to "approved" in the wcag-act-rules repository in a given branch. 
+name: Set a rule to approved
+on:
+  workflow_dispatch:
+    inputs:
+      ruleId:
+        description: 'Rule ID'
+        required: true
+      branch:
+        description: 'Target branch name (new or existing)'
+        required: true
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check user permission
+        uses: 74th/workflow-permission-action@1.0.0
+        with:
+          listfile: .github/workflows/chair-accounts.md
+
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: npm
+      - uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: git config --global url."https://github.com/".insteadOf ssh://git@github.com/
+      - name: Install dependencies
+        run: npm ci
+      - name: Configure git
+        run: |
+          git config --global url."https://${{ secrets.WAI_GIT_NAME }}:${{ secrets.WAI_GIT_ACCESS_TOKEN }}@github.com".insteadOf "https://github.com"
+          git config --global user.name "${{ secrets.WAI_GIT_NAME }}"
+          git config --global user.email "${{ secrets.WAI_GIT_EMAIL }}"
+      - name: Set rule to approved
+        run: npx zx .github/scripts/wai-build.mjs --ruleId ${{ github.event.inputs.ruleId }}" --branch ${{ github.event.inputs.branch }}"

--- a/.github/workflows/chair-accounts.md
+++ b/.github/workflows/chair-accounts.md
@@ -1,0 +1,4 @@
+WilcoFiers
+daniel-montalvo
+tbostic32
+kengdoj

--- a/README.md
+++ b/README.md
@@ -30,5 +30,9 @@ ACT-R has conference calls every 4 weeks. If you are interested in becoming an a
 
 For info on how to use this GitHub repository, see the [ACT-Rules GitHub Guidelines](github-guidelines.md).
 
+## GitHub Automation
+
+This repository automatically pushes changes to rules to the [w3c/wcag-act-rules](https://github.com/w3c/wcag-act-rules/) repository. There is an "Approve rule" action available which can be triggered manually by an ACT Task Force facilitator, which will set a proposed rule to "approved".
+
 [wcag21]: https://www.w3.org/TR/WCAG21/
 [act-r]: https://www.w3.org/community/act-r/

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
 				"js-yaml": "^3.14.1",
 				"lint-staged": "^9.5.0",
 				"marked": "^4.0.10",
+				"moment": "^2.29.4",
 				"prettier": "^1.19.1",
 				"remark-frontmatter": "^1.3.2",
 				"remark-parse": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
 		"js-yaml": "^3.14.1",
 		"lint-staged": "^9.5.0",
 		"marked": "^4.0.10",
+		"moment": "^2.29.4",
 		"prettier": "^1.19.1",
 		"remark-frontmatter": "^1.3.2",
 		"remark-parse": "^8.0.3",


### PR DESCRIPTION
This script sets a rule as approved on the WAI website. It  can be triggered from the "Actions" tab, but only by one of the ACT TF leads. When activating the action, it'll ask for a rule ID and branch.

This cannot be used to update a rule that's already approved. I'll need to create a separate action for that.

Need for Call for Review: none