### PR TITLE
Table headers - No ARIA tables  and TF feedback

### DIFF
--- a/__tests__/spelling-ignore.yml
+++ b/__tests__/spelling-ignore.yml
@@ -168,6 +168,7 @@
 - isComposing
 - x1
 - y1
+- rowIndex
 
 # DOM Events
 - auxclick

--- a/__tests__/spelling-ignore.yml
+++ b/__tests__/spelling-ignore.yml
@@ -169,6 +169,7 @@
 - x1
 - y1
 - rowIndex
+- textContent
 
 # DOM Events
 - auxclick

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -26,12 +26,12 @@ acknowledgments:
 
 ## Applicability
 
-This rule applies to any non-empty `th` element that is [included in the accessibility tree][], has a [semantic role][] of [rowheader][] or [columnheader][], and for which all of the following are true:
+This rule applies to any [non-empty][] `th` element that is [included in the accessibility tree][], has a [semantic role][] of [rowheader][] or [columnheader][], and for which all of the following are true:
 
 - **in a table** the `th` element is a [descendant][] of a `table` element for which all of the following are true:
   - **visible** the `table` element is [visible][]; and
   - **minimum rows** the `table` element's [`rows` collection](https://html.spec.whatwg.org/multipage/tables.html#dom-table-rows) has 2 or more `tr` elements; and
-  - **non-empty data cell** the `table` element has at least one non-empty `td` element that is a [child][] of a `tr` element with the [`rowIndex`][rowindex] value of 1 or more if the `tr` element with the value of 0 has at least two `th` [children][child] or the value of 0 or more if the `tr` element with the value of 0 has one or less `th` [children][child].
+  - **non-empty data cell** the `table` element has at least one [non-empty][] `td` element that is a [child][] of a `tr` element with the [`rowIndex`][rowindex] value of 1 or more if the `tr` element with the value of 0 has at least two `th` [children][child] or the value of 0 or more if the `tr` element with the value of 0 has one or less `th` [children][child].
 - **no explicit role** none of the elements that make up the [table model][] have an [explicit semantic role][].
 
 ## Expectation
@@ -102,7 +102,7 @@ Each of the 2 `th` elements is assigned to the `td` element because this `td` el
 
 #### Passed Example 3
 
-Each of the 4 non-empty `th` elements is assigned to a `td` element, within the same `table` element.
+Each of the 4 [non-empty][] `th` elements is assigned to a `td` element, within the same `table` element.
 
 ```html
 <table>
@@ -371,7 +371,7 @@ This `table` element is not [visible][].
 
 #### Inapplicable Example 11
 
-This `table` element does not have a non-empty `td` element.
+This `table` element does not have a [non-empty][] `td` element.
 
 ```html
 <table>
@@ -388,7 +388,7 @@ This `table` element does not have a non-empty `td` element.
 
 #### Inapplicable Example 12
 
-There are no non-empty `th` elements in the `table` element.
+There are no [non-empty][] `th` elements in the `table` element.
 
 ```html
 <table>
@@ -404,6 +404,7 @@ There are no non-empty `th` elements in the `table` element.
 ```
 
 [attribute value]: #attribute-value 'Definition of attribute value'
+[non-empty]: #non-empty 'Definition of non-empty'
 [child]: https://dom.spec.whatwg.org/#concept-tree-child 'Definition of child'
 [explicit semantic role]: #explicit-role 'Definition of explicit semantic role'
 [rowindex]: https://html.spec.whatwg.org/multipage/tables.html#dom-tr-rowindex 'Definition of rowIndex'

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -1,9 +1,9 @@
 ---
 id: d0f69e
-name: Table header cell has assigned cells
+name: Table header cell is assigned to a cell
 rule_type: atomic
 description: |
-  This rule checks that each table header has assigned cells in a table element.
+  This rule checks that each table header is assigned to at least one cell.
 accessibility_requirements:
   wcag20:1.3.1: # Info and Relationships (A)
     forConformance: true
@@ -24,16 +24,17 @@ acknowledgments:
 
 ## Applicability
 
-This rule applies to any [HTML element][] with a [semantic][semantic role] [rowheader][] or [columnheader][] for which all of the following is true:
+This rule applies to any `th` element that is [included in the accessibility tree][], has a [semantic role][] of [rowheader][] or [columnheader][], and for which all of the following are true:
 
-- the element is [visible][]; and
-- the element is [included in the accessibility tree][]; and
-- the element has at least one ancestor in the [flat tree][] that is a [semantic][semantic role] [table][] or [grid][]; and
-- the element's closest ancestor in the [flat tree][] that is a [semantic][semantic role] [table][] or [grid][] is [included in the accessibility tree][].
+- **in a row** the element is a child of a `tr` element; and
+- **table** the element is an [inclusive descendant][] of a `table` element; and
+- **minimum rows** the `table` element has at least two `tr` elements as its [inclusive descendant][] elements; and
+- **visible** the `table` element is [visible][]; and
+- **no explicit role** the `th`, `tr`, `table`, and another elements in between them do not have an [explicit semantic role][].
 
 ## Expectation
 
-Each target element is [assigned][] to at least one element with an [inheriting semantic][] [cell][].
+Each target element is [assigned][] to at least one `td` or `th` element.
 
 ## Assumptions
 
@@ -341,18 +342,15 @@ This `th` element is part of a table which is not [included in the accessibility
 </table>
 ```
 
+[explicit semantic role]: #explicit-role 'Definition of explicit semantic role'
 [semantic role]: #semantic-role 'Definition of semantic role'
 [visible]: #visible 'Definition of visible'
-[inheriting semantic]: #inheriting-semantic 'Definition of Inheriting Semantic Role'
 [included in the accessibility tree]: #included-in-the-accessibility-tree 'Definition of included in the accessibility tree'
+[inclusive descendant]: https://dom.spec.whatwg.org/#concept-tree-inclusive-descendant 'Definition of inclusive descendant'
 [assigned]: https://html.spec.whatwg.org/multipage/tables.html#header-and-data-cell-semantics 'Forming relationships between data cells and header cells'
-[cell]: https://www.w3.org/TR/wai-aria-1.1/#cell 'ARIA cell role'
 [flat tree]: https://drafts.csswg.org/css-scoping/#flat-tree 'Definition of flat tree'
-[table]: https://www.w3.org/TR/wai-aria-1.1/#table 'ARIA table role'
-[grid]: https://www.w3.org/TR/wai-aria-1.1/#grid 'ARIA grid role'
 [columnheader]: https://www.w3.org/TR/wai-aria-1.1/#columnheader 'ARIA columnheader role'
 [rowheader]: https://www.w3.org/TR/wai-aria-1.1/#rowheader 'ARIA rowheader role'
 [explicit role]: #explicit-role 'Definition of Explicit Role'
 [presentational roles conflict resolution]: https://www.w3.org/TR/wai-aria-1.1/#conflict_resolution_presentation_none 'Presentational Roles Conflict Resolution'
 [sc1.3.1]: https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html 'Understanding Success Criterion 1.3.1: Info and Relationships'
-[html element]: #namespaced-element

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -18,6 +18,7 @@ acknowledgments:
   authors:
     - Aron Janecki
     - Audrey Maniez
+    - Jean-Yves Moyen
     - Jey Nandakumar
   funding:
     - WAI-Tools

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -48,12 +48,13 @@ Some popular combinations of browsers and assistive technologies disregard the `
 
 ## Background
 
-The roles inheriting from `cell` are `columnheader`, `gridcell`, and `rowheader`.
+The [HTML specification](https://html.spec.whatwg.org/) contains the [internal algorithm for scanning and assigning header cells](https://html.spec.whatwg.org/multipage/tables.html#internal-algorithm-for-scanning-and-assigning-header-cells) which indicates that the `th` elements with a `scope` [attribute value][] of `auto`, and both a data cell in their row and one in their column are neither row header nor column header. However, some browsers give those `th` elements a table header role and this process is not standardized. One browser may evaluate such `th` elements as [rowheader][] whereas other browsers may evaluate the same `th` elements as [columnheader][]. This is likely not going to convey the relationship conveyed through presentation.
 
-### Bibliography
+This rule does not apply to tables and grids built using [WAI-ARIA 1.1][] [explicit semantic roles][explicit semantic role] as it is not clear how the process of assigning table headers works for such elements.
 
 - [Understanding Success Criterion 1.3.1: Information and relationships][sc1.3.1]
 - [H43: Using id and headers attributes to associate data cells with header cells in data tables](https://www.w3.org/WAI/WCAG21/Techniques/html/H43)
+- [H63: Using the scope attribute to associate header cells and data cells in data tables](https://www.w3.org/WAI/WCAG21/Techniques/html/H63)
 - [Forming relationships between data cells and header cells][assigned]
 
 ## Test Cases
@@ -343,6 +344,7 @@ This `th` element is part of a table which is not [included in the accessibility
 </table>
 ```
 
+[attribute value]: #attribute-value 'Definition of attribute value'
 [explicit semantic role]: #explicit-role 'Definition of explicit semantic role'
 [semantic role]: #semantic-role 'Definition of semantic role'
 [visible]: #visible 'Definition of visible'
@@ -355,3 +357,4 @@ This `th` element is part of a table which is not [included in the accessibility
 [explicit role]: #explicit-role 'Definition of Explicit Role'
 [presentational roles conflict resolution]: https://www.w3.org/TR/wai-aria-1.1/#conflict_resolution_presentation_none 'Presentational Roles Conflict Resolution'
 [sc1.3.1]: https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html 'Understanding Success Criterion 1.3.1: Info and Relationships'
+[wai-aria 1.1]: https://www.w3.org/TR/wai-aria-1.1/ 'WAI-ARIA 1.1'

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -80,31 +80,6 @@ This `th` element is [assigned][] to at least one `td` element.
 
 #### Passed Example 2
 
-Each of the 2 `span` elements with role of `columnheader` has assigned `span` elements with a role of `cell`.
-
-```html
-<div role="table">
-	<div role="rowgroup">
-		<div role="row">
-			<span role="columnheader">Month</span>
-			<span role="columnheader">Top Temperature</span>
-		</div>
-	</div>
-	<div role="rowgroup">
-		<div role="row">
-			<span role="cell">July</span>
-			<span role="cell">40 C</span>
-		</div>
-		<div role="row">
-			<span role="cell">August</span>
-			<span role="cell">45 C</span>
-		</div>
-	</div>
-</div>
-```
-
-#### Passed Example 3
-
 Each of the 2 `th` elements has an assigned `td` element because this `td` element spans 2 columns.
 
 ```html
@@ -123,7 +98,7 @@ Each of the 2 `th` elements has an assigned `td` element because this `td` eleme
 </table>
 ```
 
-#### Passed Example 4
+#### Passed Example 3
 
 Each of the 4 `th` elements has an assigned `td` element, within the same `table` element having a [semantic role][] of `grid`.
 
@@ -148,7 +123,7 @@ Each of the 4 `th` elements has an assigned `td` element, within the same `table
 </table>
 ```
 
-#### Passed Example 5
+#### Passed Example 4
 
 Each of the 2 `th` elements has an assigned `td` element because the `headers` attribute assigns the `th` with `id` equal to "col2" to the `td` element.
 
@@ -167,7 +142,7 @@ Each of the 2 `th` elements has an assigned `td` element because the `headers` a
 </table>
 ```
 
-#### Passed Example 6
+#### Passed Example 5
 
 Each of the 5 `th` elements in this table has assigned cells, whether data or header.
 
@@ -231,25 +206,6 @@ This `th` element with `id` equal to "col2" does not have an assigned cell withi
 		<td headers="col1">Zimbabwe</td>
 	</tr>
 </table>
-```
-
-#### Failed Example 3
-
-This `div` with role of `columnheader` and text equal to "Occupant" does not have an assigned cell within the same `table` element.
-
-```html
-<div role="grid">
-	<div role="row">
-		<div role="columnheader">Room</div>
-		<div role="columnheader">Occupant</div>
-	</div>
-	<div role="row">
-		<div role="gridcell">1A</div>
-	</div>
-	<div role="row">
-		<div role="gridcell">2A</div>
-	</div>
-</div>
 ```
 
 ### Inapplicable

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -28,11 +28,11 @@ acknowledgments:
 This rule applies to any non-empty `th` element that is [included in the accessibility tree][], has a [semantic role][] of [rowheader][] or [columnheader][], and for which all of the following are true:
 
 - **in a table** the `th` element is an [inclusive descendant][] of a `table` element for which all of the following are true:
-- **visible** the `table` element is [visible][]; and
-- **minimum rows** the `table` element has at least two `tr` elements as its [inclusive descendant][] elements; and
-- **content model** the `table` and its [inclusive descendant][] `tr` elements follow theirs [content model](https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model); and
-- **non-empty data cell** the `table` element has at least one non-empty `td` element, and
-- **no explicit role** the `th`, `tr`, `table`, and other elements in between them do not have an [explicit semantic role][], and
+  - **visible** the `table` element is [visible][]; and
+  - **minimum rows** the `table` element has at least two `tr` elements as its [inclusive descendant][] elements; and
+  - **content model** the `table` and its [inclusive descendant][] `tr` elements follow theirs [content model](https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model); and
+  - **non-empty data cell** the `table` element has at least one non-empty `td` element.
+- **no explicit role** the `th`, `tr`, `table`, and other elements in between them do not have an [explicit semantic role][].
 
 ## Expectation
 

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -316,7 +316,7 @@ This `th` element is not [included in the accessibility tree][] because of the `
 
 #### Inapplicable Example 7
 
-This `th` element is a child of a `tr` element but the `tr` element is not an [descendant][] of a `table` element.
+This `th` element is not an [descendant][] of a `table` element.
 
 ```html
 <div>
@@ -370,7 +370,7 @@ This `table` element is not [visible][].
 
 #### Inapplicable Example 11
 
-This `table` element does not have at least one `th` element that is assigned to a non-empty `td` element.
+This `table` element does not have a non-empty `td` element.
 
 ```html
 <table>
@@ -387,7 +387,7 @@ This `table` element does not have at least one `th` element that is assigned to
 
 #### Inapplicable Example 12
 
-There are no non-empty `th` element in the `table` element.
+There are no non-empty `th` elements in the `table` element.
 
 ```html
 <table>

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -27,7 +27,7 @@ acknowledgments:
 This rule applies to any non-empty `th` element that is [included in the accessibility tree][], has a [semantic role][] of [rowheader][] or [columnheader][], and for which all of the following are true:
 
 - **in a row** the element is a child of a `tr` element; and
-- **table** the element is an [inclusive descendant][] of a `table` element; and
+- **table** the `tr` element is an [inclusive descendant][] of a `table` element; and
 - **minimum rows** the `table` element has at least two `tr` elements as its [inclusive descendant][] elements; and
 - **non-empty** the `table` element has at least one `th` element that is assigned to a non-empty `td` element, and
 - **visible** the `table` element is [visible][]; and
@@ -216,7 +216,7 @@ This `th` element with `id` equal to "col2" is not assigned to a `td` or a `th` 
 
 #### Inapplicable Example 1
 
-There are no elements with a [semantic role][] of `header` within the `table` element.
+There are no `th` elements with a [semantic role][] of [rowheader][] or [columnheader][] within the `table` element.
 
 ```html
 <table>
@@ -228,7 +228,7 @@ There are no elements with a [semantic role][] of `header` within the `table` el
 
 #### Inapplicable Example 2
 
-There are no elements with a [semantic role][] of `header` within the `table` element.
+There are no `th` elements within the `table` element.
 
 ```html
 <table></table>
@@ -236,12 +236,12 @@ There are no elements with a [semantic role][] of `header` within the `table` el
 
 #### Inapplicable Example 3
 
-This `th` element has an [explicit role][] of `cell` and there are no more elements with a [semantic role][] of `header` within the `table` element.
+This `th` element has an [explicit semantic role][] of `columnheader`.
 
 ```html
 <table>
 	<tr>
-		<th role="cell">Column A</th>
+		<th role="columnheader">Column A</th>
 	</tr>
 	<tr>
 		<td>Cell A</td>
@@ -251,7 +251,24 @@ This `th` element has an [explicit role][] of `cell` and there are no more eleme
 
 #### Inapplicable Example 4
 
-This `th` element is neither [visible][] nor [included in the accessibility tree][] and there are no more elements with a [semantic role][] of `header` within the `table` element.
+This `tbody` element has an [explicit semantic role][] of `rowgroup`.
+
+```html
+<table>
+	<thead role="rowgroup">
+		<tr>
+			<th>Column A</th>
+		</tr>
+	</thead>
+	<tr>
+		<td>Cell A</td>
+	</tr>
+</table>
+```
+
+#### Inapplicable Example 5
+
+This `th` element is not [included in the accessibility tree][] because of the `style="display: none;"` attribute and there are no more `th` elements within the `table` element.
 
 ```html
 <table>
@@ -264,9 +281,9 @@ This `th` element is neither [visible][] nor [included in the accessibility tree
 </table>
 ```
 
-#### Inapplicable Example 5
+#### Inapplicable Example 6
 
-This `th` element is not [included in the accessibility tree][] and there are no more elements with a [semantic role][] of `header` within the `table` element.
+This `th` element is not [included in the accessibility tree][] beause of the `aria-hidden="true"` attribute and there are no more `th` elements within the `table` element.
 
 ```html
 <table>
@@ -279,9 +296,9 @@ This `th` element is not [included in the accessibility tree][] and there are no
 </table>
 ```
 
-#### Inapplicable Example 6
+#### Inapplicable Example 7
 
-This `th` element is not a descendant in the [flat tree][] of a [semantic][semantic role] `table` or `grid`.
+This `th` element is a child of a `tr` element but the `tr` element is not an [inclusive descendant][] of a `table` element.
 
 ```html
 <div>
@@ -291,9 +308,9 @@ This `th` element is not a descendant in the [flat tree][] of a [semantic][seman
 </div>
 ```
 
-#### Inapplicable Example 7
+#### Inapplicable Example 8
 
-This `th` element is part of a table which is not [included in the accessibility tree][].
+This `th` element does not have a [semantic role][] of a `columnheader` through the use of `role="presentation"` on the `table` element.
 
 ```html
 <table role="presentation">
@@ -302,6 +319,50 @@ This `th` element is part of a table which is not [included in the accessibility
 	</tr>
 	<tr>
 		<td>12:00</td>
+	</tr>
+</table>
+```
+
+#### Inapplicable Example 9
+
+This `table` element has only one `tr` element as its [inclusive descendant][].
+
+```html
+<table>
+	<tr>
+		<th>Time</th>
+	</tr>
+</table>
+```
+
+#### Inapplicable Example 10
+
+This `table` element is not [visible][].
+
+```html
+<table style="display: none;">
+	<tr>
+		<th>Time</th>
+	</tr>
+	<tr>
+		<td>12:00</td>
+	</tr>
+</table>
+```
+
+#### Inapplicable Example 11
+
+This `table` element does not have at least one `th` element that is assigned to a non-empty `td` element.
+
+```html
+<table>
+	<tr>
+		<th>Country</th>
+		<th>Capital</th>
+	</tr>
+	<tr>
+		<td></td>
+		<td></td>
 	</tr>
 </table>
 ```

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -44,8 +44,6 @@ This rule assumes that table header cells have a relationship conveyed through t
 
 ## Accessibility Support
 
-Implementation of [Presentational Roles Conflict Resolution][] varies from one browser or assistive technology to another. Depending on this, some elements can have one of the applicable [semantic roles][semantic role] and fail this rule with some technology but users of other technologies would not experience any accessibility issue.
-
 Some popular combinations of browsers and assistive technologies disregard the `headers` attribute depending on the structure of the `table` element.
 
 ## Background

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -29,8 +29,8 @@ This rule applies to any non-empty `th` element that is [included in the accessi
 
 - **in a table** the `th` element is an [descendant][] of a `table` element for which all of the following are true:
   - **visible** the `table` element is [visible][]; and
-  - **content model** the `table` and its [descendant][] `tr` elements follow theirs [content model](https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model); and
-  - **non-empty data cell** the `table` element has at least one non-empty `td` element in.
+  - **content model** the `table` and its [descendant][] `tr` elements follow theirs [content model][]; and
+  - **non-empty data cell** the `table` element has at least one non-empty `td` element that is a [child][] of a `tr` element with the [index](https://dom.spec.whatwg.org/#concept-tree-index) of 1 if .
 - **no explicit role** the `th`, `tr`, `table`, and other elements in between them do not have an [explicit semantic role][].
 
 ## Expectation
@@ -403,6 +403,8 @@ There are no non-empty `th` element in the `table` element.
 ```
 
 [attribute value]: #attribute-value 'Definition of attribute value'
+[child]: https://dom.spec.whatwg.org/#concept-tree-child 'Definition of child'
+[content model]: https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model 'Definition of content model'
 [explicit semantic role]: #explicit-role 'Definition of explicit semantic role'
 [semantic role]: #semantic-role 'Definition of semantic role'
 [visible]: #visible 'Definition of visible'

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -29,8 +29,9 @@ This rule applies to any non-empty `th` element that is [included in the accessi
 - **in a row** the element is a child of a `tr` element; and
 - **table** the element is an [inclusive descendant][] of a `table` element; and
 - **minimum rows** the `table` element has at least two `tr` elements as its [inclusive descendant][] elements; and
+- **non-empty** the `table` element has at least one `th` element that is assigned to a non-empty `td` element, and
 - **visible** the `table` element is [visible][]; and
-- **no explicit role** the `th`, `tr`, `table`, and another elements in between them do not have an [explicit semantic role][].
+- **no explicit role** the `th`, `tr`, `table`, and another elements in between them do not have an [explicit semantic role][], and
 
 ## Expectation
 

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -38,7 +38,7 @@ Each target element is [assigned][] to at least one `td` or `th` element.
 
 ## Assumptions
 
-This rule assumes that table header cells have a relationship conveyed through presentation with other cells within the same table. This excludes edge cases such as a table definition where there is only one header cell, or a table definition where there are multiple headers and no other cells. In such scenarios the rule fails, but [success criterion 1.3.1 Info and Relationships][sc1.3.1] could still be satisfied.
+This rule assumes that table header cells have a relationship conveyed through the presentation with other cells within the same table. It excludes edge cases such as a table definition with only one header cell or a table definition with multiple headers and no other cells that would correspond to them. The rule fails in such scenarios, but [success criterion 1.3.1 Info and Relationships][sc1.3.1] could still be satisfied.
 
 ## Accessibility Support
 

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -16,6 +16,7 @@ input_aspects:
   - DOM Tree
 acknowledgments:
   authors:
+    - Aron Janecki
     - Audrey Maniez
     - Jey Nandakumar
   funding:

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -367,6 +367,23 @@ This `table` element does not have at least one `th` element that is assigned to
 </table>
 ```
 
+#### Inapplicable Example 11
+
+There are no non-empty `th` element in the `table` element.
+
+```html
+<table>
+	<tr>
+		<th></th>
+		<th></th>
+	</tr>
+	<tr>
+		<td>United Kingdom</td>
+		<td>London</td>
+	</tr>
+</table>
+```
+
 [attribute value]: #attribute-value 'Definition of attribute value'
 [explicit semantic role]: #explicit-role 'Definition of explicit semantic role'
 [semantic role]: #semantic-role 'Definition of semantic role'

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -27,11 +27,10 @@ acknowledgments:
 
 This rule applies to any non-empty `th` element that is [included in the accessibility tree][], has a [semantic role][] of [rowheader][] or [columnheader][], and for which all of the following are true:
 
-- **in a table** the `th` element is an [inclusive descendant][] of a `table` element for which all of the following are true:
+- **in a table** the `th` element is an [descendant][] of a `table` element for which all of the following are true:
   - **visible** the `table` element is [visible][]; and
-  - **minimum rows** the `table` element has at least two `tr` elements as its [inclusive descendant][] elements; and
-  - **content model** the `table` and its [inclusive descendant][] `tr` elements follow theirs [content model](https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model); and
-  - **non-empty data cell** the `table` element has at least one non-empty `td` element.
+  - **content model** the `table` and its [descendant][] `tr` elements follow theirs [content model](https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model); and
+  - **non-empty data cell** the `table` element has at least one non-empty `td` element in.
 - **no explicit role** the `th`, `tr`, `table`, and other elements in between them do not have an [explicit semantic role][].
 
 ## Expectation
@@ -317,7 +316,7 @@ This `th` element is not [included in the accessibility tree][] because of the `
 
 #### Inapplicable Example 7
 
-This `th` element is a child of a `tr` element but the `tr` element is not an [inclusive descendant][] of a `table` element.
+This `th` element is a child of a `tr` element but the `tr` element is not an [descendant][] of a `table` element.
 
 ```html
 <div>
@@ -344,7 +343,7 @@ This `th` element does not have a [semantic role][] of a `columnheader` through 
 
 #### Inapplicable Example 9
 
-This `table` element has only one `tr` element as its [inclusive descendant][].
+This `table` element has only one `tr` element as its [descendant][].
 
 ```html
 <table>
@@ -408,7 +407,7 @@ There are no non-empty `th` element in the `table` element.
 [semantic role]: #semantic-role 'Definition of semantic role'
 [visible]: #visible 'Definition of visible'
 [included in the accessibility tree]: #included-in-the-accessibility-tree 'Definition of included in the accessibility tree'
-[inclusive descendant]: https://dom.spec.whatwg.org/#concept-tree-inclusive-descendant 'Definition of inclusive descendant'
+[descendant]: https://dom.spec.whatwg.org/#concept-tree-descendant 'Definition of descendant'
 [assigned]: https://html.spec.whatwg.org/multipage/tables.html#header-and-data-cell-semantics 'Forming relationships between data cells and header cells'
 [columnheader]: https://www.w3.org/TR/wai-aria-1.1/#columnheader 'ARIA columnheader role'
 [rowheader]: https://www.w3.org/TR/wai-aria-1.1/#rowheader 'ARIA rowheader role'

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -1,9 +1,9 @@
 ---
 id: d0f69e
-name: Table header cell is assigned to a cell
+name: Non-empty table header cell is assigned to a cell
 rule_type: atomic
 description: |
-  This rule checks that each table header is assigned to at least one cell.
+  This rule checks that each non-empty table header is assigned to at least one cell.
 accessibility_requirements:
   wcag20:1.3.1: # Info and Relationships (A)
     forConformance: true

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -30,9 +30,9 @@ This rule applies to any non-empty `th` element that is [included in the accessi
 - **in a row** the element is a child of a `tr` element; and
 - **table** the `tr` element is an [inclusive descendant][] of a `table` element; and
 - **minimum rows** the `table` element has at least two `tr` elements as its [inclusive descendant][] elements; and
-- **non-empty** the `table` element has at least one `th` element that is assigned to a non-empty `td` element, and
+- **non-empty** the `table` element has at least one non-empty `td` element, and
 - **visible** the `table` element is [visible][]; and
-- **no explicit role** the `th`, `tr`, `table`, and another elements in between them do not have an [explicit semantic role][], and
+- **no explicit role** the `th`, `tr`, `table`, and other elements in between them do not have an [explicit semantic role][], and
 
 ## Expectation
 

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -24,7 +24,7 @@ acknowledgments:
 
 ## Applicability
 
-This rule applies to any `th` element that is [included in the accessibility tree][], has a [semantic role][] of [rowheader][] or [columnheader][], and for which all of the following are true:
+This rule applies to any non-empty `th` element that is [included in the accessibility tree][], has a [semantic role][] of [rowheader][] or [columnheader][], and for which all of the following are true:
 
 - **in a row** the element is a child of a `tr` element; and
 - **table** the element is an [inclusive descendant][] of a `table` element; and
@@ -100,21 +100,21 @@ Each of the 2 `th` elements has an assigned `td` element because this `td` eleme
 
 #### Passed Example 3
 
-Each of the 4 `th` elements has an assigned `td` element, within the same `table` element having a [semantic role][] of `grid`.
+Each of the 4 non-empty `th` elements is assigned to a `td` element, within the same `table` element.
 
 ```html
-<table role="grid">
+<table>
 	<thead>
-		<tr role="row">
-			<td></td>
-			<th scope="col" role="columnheader">Breakfast</th>
-			<th scope="col" role="columnheader">Lunch</th>
-			<th scope="col" role="columnheader">Dinner</th>
+		<tr>
+			<th></th>
+			<th scope="col">Breakfast</th>
+			<th scope="col">Lunch</th>
+			<th scope="col">Dinner</th>
 		</tr>
 	</thead>
 	<tbody>
-		<tr role="row">
-			<th scope="row" role="rowheader">Day 1</th>
+		<tr>
+			<th scope="row">Day 1</th>
 			<td>8:00</td>
 			<td>13:00</td>
 			<td>18:00</td>

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -40,7 +40,7 @@ Each target element is [assigned][] to at least one `td` or `th` element.
 
 ## Assumptions
 
-This rule assumes that table header cells have a relationship conveyed through the presentation with other cells within the same table.
+This rule assumes that table header cells have a relationship with other cells within the same table, conveyed through presentation .
 
 ## Accessibility Support
 

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -63,15 +63,17 @@ This rule does not apply to tables and grids built using [WAI-ARIA 1.1][] [expli
 
 #### Passed Example 1
 
-This `th` element has an assigned `td` element.
+This `th` element is [assigned][] to at least one `td` element.
 
 ```html
 <table>
 	<tr>
 		<th>Time</th>
+		<th>Date</th>
 	</tr>
 	<tr>
 		<td>05:41</td>
+		<td>12/07/2021</td>
 	</tr>
 </table>
 ```

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -50,7 +50,7 @@ Some popular combinations of browsers and assistive technologies disregard the `
 
 The [HTML specification](https://html.spec.whatwg.org/) contains the [internal algorithm for scanning and assigning header cells](https://html.spec.whatwg.org/multipage/tables.html#internal-algorithm-for-scanning-and-assigning-header-cells) which indicates that the `th` elements with a `scope` [attribute value][] of `auto`, and both a data cell in their row and one in their column are neither row header nor column header. However, some browsers give those `th` elements a table header role and this process is not standardized. One browser may evaluate such `th` elements as [rowheader][] whereas other browsers may evaluate the same `th` elements as [columnheader][]. This is likely not going to convey the relationship conveyed through presentation.
 
-This rule does not apply to tables and grids built using [WAI-ARIA 1.1][] [explicit semantic roles][explicit semantic role] as it is not clear how the process of assigning table headers works for such elements.
+This rule does not apply to tables and grids built using [WAI-ARIA 1.2][] [explicit semantic roles][explicit semantic role] as it is not clear how the process of assigning table headers works for such elements.
 
 - [Understanding Success Criterion 1.3.1: Information and relationships][sc1.3.1]
 - [H43: Using id and headers attributes to associate data cells with header cells in data tables](https://www.w3.org/WAI/WCAG21/Techniques/html/H43)
@@ -416,4 +416,4 @@ There are no [non-empty][] `th` elements in the `table` element.
 [presentational roles conflict resolution]: https://www.w3.org/TR/wai-aria-1.1/#conflict_resolution_presentation_none 'Presentational Roles Conflict Resolution'
 [table model]: https://html.spec.whatwg.org/multipage/tables.html#table-model 'Definition of table model'
 [sc1.3.1]: https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html 'Understanding Success Criterion 1.3.1: Info and Relationships'
-[wai-aria 1.1]: https://www.w3.org/TR/wai-aria-1.1/ 'WAI-ARIA 1.1'
+[wai-aria 1.2]: https://www.w3.org/TR/wai-aria-1.2/ 'WAI-ARIA 1.2'

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -27,11 +27,11 @@ acknowledgments:
 
 This rule applies to any non-empty `th` element that is [included in the accessibility tree][], has a [semantic role][] of [rowheader][] or [columnheader][], and for which all of the following are true:
 
-- **in a table** the `th` element is an [descendant][] of a `table` element for which all of the following are true:
+- **in a table** the `th` element is a [descendant][] of a `table` element for which all of the following are true:
   - **visible** the `table` element is [visible][]; and
-  - **content model** the `table` and its [descendant][] `tr` elements follow theirs [content model][]; and
-  - **non-empty data cell** the `table` element has at least one non-empty `td` element that is a [child][] of a `tr` element with the [index](https://dom.spec.whatwg.org/#concept-tree-index) of 1 if .
-- **no explicit role** the `th`, `tr`, `table`, and other elements in between them do not have an [explicit semantic role][].
+  - **minimum rows** the `table` element's [`rows` collection](https://html.spec.whatwg.org/multipage/tables.html#dom-table-rows) has 2 or more `tr` elements; and
+  - **non-empty data cell** the `table` element has at least one non-empty `td` element that is a [child][] of a `tr` element with the [`rowIndex`][] value of 1 or more if the `tr` element with the value of 0 has at least two `th` [children][child] or the value of 0 or more if the `tr` element with the value of 0 has one or less `th` [children][child].
+- **no explicit role** none of the elements that make up the [table model][] have an [explicit semantic role][].
 
 ## Expectation
 
@@ -404,8 +404,8 @@ There are no non-empty `th` element in the `table` element.
 
 [attribute value]: #attribute-value 'Definition of attribute value'
 [child]: https://dom.spec.whatwg.org/#concept-tree-child 'Definition of child'
-[content model]: https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model 'Definition of content model'
 [explicit semantic role]: #explicit-role 'Definition of explicit semantic role'
+[rowindex]: https://html.spec.whatwg.org/multipage/tables.html#dom-tr-rowindex 'Definition of rowIndex'
 [semantic role]: #semantic-role 'Definition of semantic role'
 [visible]: #visible 'Definition of visible'
 [included in the accessibility tree]: #included-in-the-accessibility-tree 'Definition of included in the accessibility tree'
@@ -414,5 +414,6 @@ There are no non-empty `th` element in the `table` element.
 [columnheader]: https://www.w3.org/TR/wai-aria-1.1/#columnheader 'ARIA columnheader role'
 [rowheader]: https://www.w3.org/TR/wai-aria-1.1/#rowheader 'ARIA rowheader role'
 [presentational roles conflict resolution]: https://www.w3.org/TR/wai-aria-1.1/#conflict_resolution_presentation_none 'Presentational Roles Conflict Resolution'
+[table model]: https://html.spec.whatwg.org/multipage/tables.html#table-model 'Definition of table model'
 [sc1.3.1]: https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html 'Understanding Success Criterion 1.3.1: Info and Relationships'
 [wai-aria 1.1]: https://www.w3.org/TR/wai-aria-1.1/ 'WAI-ARIA 1.1'

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -40,7 +40,7 @@ Each target element is [assigned][] to at least one `td` or `th` element.
 
 ## Assumptions
 
-This rule assumes that table header cells have a relationship conveyed through the presentation with other cells within the same table. It excludes edge cases such as a table definition with only one header cell or a table definition with multiple headers and no other cells that would correspond to them. The rule fails in such scenarios, but [success criterion 1.3.1 Info and Relationships][sc1.3.1] could still be satisfied.
+This rule assumes that table header cells have a relationship conveyed through the presentation with other cells within the same table.
 
 ## Accessibility Support
 

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -283,7 +283,7 @@ This `th` element is not [included in the accessibility tree][] because of the `
 
 #### Inapplicable Example 6
 
-This `th` element is not [included in the accessibility tree][] beause of the `aria-hidden="true"` attribute and there are no more `th` elements within the `table` element.
+This `th` element is not [included in the accessibility tree][] because of the `aria-hidden="true"` attribute and there are no more `th` elements within the `table` element.
 
 ```html
 <table>
@@ -367,7 +367,7 @@ This `table` element does not have at least one `th` element that is assigned to
 </table>
 ```
 
-#### Inapplicable Example 11
+#### Inapplicable Example 12
 
 There are no non-empty `th` element in the `table` element.
 
@@ -391,10 +391,8 @@ There are no non-empty `th` element in the `table` element.
 [included in the accessibility tree]: #included-in-the-accessibility-tree 'Definition of included in the accessibility tree'
 [inclusive descendant]: https://dom.spec.whatwg.org/#concept-tree-inclusive-descendant 'Definition of inclusive descendant'
 [assigned]: https://html.spec.whatwg.org/multipage/tables.html#header-and-data-cell-semantics 'Forming relationships between data cells and header cells'
-[flat tree]: https://drafts.csswg.org/css-scoping/#flat-tree 'Definition of flat tree'
 [columnheader]: https://www.w3.org/TR/wai-aria-1.1/#columnheader 'ARIA columnheader role'
 [rowheader]: https://www.w3.org/TR/wai-aria-1.1/#rowheader 'ARIA rowheader role'
-[explicit role]: #explicit-role 'Definition of Explicit Role'
 [presentational roles conflict resolution]: https://www.w3.org/TR/wai-aria-1.1/#conflict_resolution_presentation_none 'Presentational Roles Conflict Resolution'
 [sc1.3.1]: https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html 'Understanding Success Criterion 1.3.1: Info and Relationships'
 [wai-aria 1.1]: https://www.w3.org/TR/wai-aria-1.1/ 'WAI-ARIA 1.1'

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -42,8 +42,9 @@ This rule assumes that table header cells have a relationship conveyed through t
 
 ## Accessibility Support
 
-- Table markup and header cell association is not well supported by some popular assistive technologies. Passing this rule can still cause issues for users of those assistive technologies.
-- Implementation of [Presentational Roles Conflict Resolution][] varies from one browser or assistive technology to another. Depending on this, some elements can have one of the applicable [semantic roles][semantic role] and fail this rule with some technology but users of other technologies would not experience any accessibility issue.
+Implementation of [Presentational Roles Conflict Resolution][] varies from one browser or assistive technology to another. Depending on this, some elements can have one of the applicable [semantic roles][semantic role] and fail this rule with some technology but users of other technologies would not experience any accessibility issue.
+
+Some popular combinations of browsers and assistive technologies disregard the `headers` attribute depending on the structure of the `table` element.
 
 ## Background
 

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -80,7 +80,7 @@ This `th` element is [assigned][] to at least one `td` element.
 
 #### Passed Example 2
 
-Each of the 2 `th` elements has an assigned `td` element because this `td` element spans 2 columns.
+Each of the 2 `th` elements is assigned to the `td` element because this `td` element spans 2 columns.
 
 ```html
 <table>
@@ -125,26 +125,29 @@ Each of the 4 non-empty `th` elements is assigned to a `td` element, within the 
 
 #### Passed Example 4
 
-Each of the 2 `th` elements has an assigned `td` element because the `headers` attribute assigns the `th` with `id` equal to "col2" to the `td` element.
+Each of the 4 `th` elements is assigned to at least one `td` element because all of the `id` values for the `th` elements are referenced by the value of the `headers` attribute on `td` elements.
 
 ```html
 <table>
 	<tr>
-		<th id="col1">Cities</th>
-		<th id="col2">Count</th>
+		<th id="projects" rowspan="2">Projects</th>
+		<th id="objective" colspan="2">Objective</th>
 	</tr>
 	<tr>
-		<td>Paris</td>
+		<th id="1" headers="objective">1</th>
+		<th id="2" headers="objective">2</th>
 	</tr>
 	<tr>
-		<td headers="col2">1</td>
+		<td headers="projects">45%</td>
+		<td headers="objective 1">20%</td>
+		<td headers="objective 2">25%</td>
 	</tr>
 </table>
 ```
 
 #### Passed Example 5
 
-Each of the 5 `th` elements in this table has assigned cells, whether data or header.
+Each of the 5 `th` elements is assigned to a `td` or a `th` element.
 
 ```html
 <table>
@@ -173,7 +176,7 @@ Each of the 5 `th` elements in this table has assigned cells, whether data or he
 
 #### Failed Example 1
 
-The `th` element with text "Value" does not have an assigned cell within the same `table` element.
+The `th` element with text "Value" is not assigned to a `td` or a `th` element.
 
 ```html
 <table>
@@ -193,7 +196,7 @@ The `th` element with text "Value" does not have an assigned cell within the sam
 
 #### Failed Example 2
 
-This `th` element with `id` equal to "col2" does not have an assigned cell within the same `table` element because the `headers` attribute removes the cell association from its column.
+This `th` element with `id` equal to "col2" is not assigned to a `td` or a `th` element because the `headers` attribute removes the cell association from its column.
 
 ```html
 <table>

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -27,11 +27,11 @@ acknowledgments:
 
 This rule applies to any non-empty `th` element that is [included in the accessibility tree][], has a [semantic role][] of [rowheader][] or [columnheader][], and for which all of the following are true:
 
-- **in a row** the element is a child of a `tr` element; and
-- **table** the `tr` element is an [inclusive descendant][] of a `table` element; and
-- **minimum rows** the `table` element has at least two `tr` elements as its [inclusive descendant][] elements; and
-- **non-empty** the `table` element has at least one non-empty `td` element, and
+- **in a table** the `th` element is an [inclusive descendant][] of a `table` element for which all of the following are true:
 - **visible** the `table` element is [visible][]; and
+- **minimum rows** the `table` element has at least two `tr` elements as its [inclusive descendant][] elements; and
+- **content model** the `table` and its [inclusive descendant][] `tr` elements folow theirs [content model](https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model); and
+- **non-empty data cell** the `table` element has at least one non-empty `td` element, and
 - **no explicit role** the `th`, `tr`, `table`, and other elements in between them do not have an [explicit semantic role][], and
 
 ## Expectation

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -30,7 +30,7 @@ This rule applies to any non-empty `th` element that is [included in the accessi
 - **in a table** the `th` element is an [inclusive descendant][] of a `table` element for which all of the following are true:
 - **visible** the `table` element is [visible][]; and
 - **minimum rows** the `table` element has at least two `tr` elements as its [inclusive descendant][] elements; and
-- **content model** the `table` and its [inclusive descendant][] `tr` elements folow theirs [content model](https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model); and
+- **content model** the `table` and its [inclusive descendant][] `tr` elements follow theirs [content model](https://html.spec.whatwg.org/multipage/dom.html#concept-element-content-model); and
 - **non-empty data cell** the `table` element has at least one non-empty `td` element, and
 - **no explicit role** the `th`, `tr`, `table`, and other elements in between them do not have an [explicit semantic role][], and
 

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -181,19 +181,37 @@ Each of the 5 `th` elements is assigned to a `td` or a `th` element.
 The `th` element with text "Value" is not assigned to a `td` or a `th` element.
 
 ```html
-<table>
-	<thead>
-		<tr>
-			<th>Rate</th>
-			<th>Value</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>15%</td>
-		</tr>
-	</tbody>
-</table>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<title>Failed Example 1</title>
+		<style>
+			table {
+				border-collapse: collapse;
+				border: hidden;
+			}
+			tr td,
+			tr th {
+				border: 1px solid grey;
+			}
+		</style>
+	</head>
+	<body>
+		<table>
+			<thead>
+				<tr>
+					<th>Rate</th>
+					<th>Value</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>15%</td>
+				</tr>
+			</tbody>
+		</table>
+	</body>
+</html>
 ```
 
 #### Failed Example 2

--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -30,7 +30,7 @@ This rule applies to any non-empty `th` element that is [included in the accessi
 - **in a table** the `th` element is a [descendant][] of a `table` element for which all of the following are true:
   - **visible** the `table` element is [visible][]; and
   - **minimum rows** the `table` element's [`rows` collection](https://html.spec.whatwg.org/multipage/tables.html#dom-table-rows) has 2 or more `tr` elements; and
-  - **non-empty data cell** the `table` element has at least one non-empty `td` element that is a [child][] of a `tr` element with the [`rowIndex`][] value of 1 or more if the `tr` element with the value of 0 has at least two `th` [children][child] or the value of 0 or more if the `tr` element with the value of 0 has one or less `th` [children][child].
+  - **non-empty data cell** the `table` element has at least one non-empty `td` element that is a [child][] of a `tr` element with the [`rowIndex`][rowindex] value of 1 or more if the `tr` element with the value of 0 has at least two `th` [children][child] or the value of 0 or more if the `tr` element with the value of 0 has one or less `th` [children][child].
 - **no explicit role** none of the elements that make up the [table model][] have an [explicit semantic role][].
 
 ## Expectation

--- a/pages/glossary/non-empty.md
+++ b/pages/glossary/non-empty.md
@@ -1,0 +1,12 @@
+---
+title: Non-empty
+key: non-empty
+unambiguous: true
+objective: true
+input_aspects:
+  - Accessibility tree
+  - CSS styling
+  - DOM tree
+---
+
+A _non-empty_ element is an element that has a `textContent` property that is neither empty (`""`) nor only [ASCII whitespace](https://infra.spec.whatwg.org/#ascii-whitespace).


### PR DESCRIPTION
A few of changes to [Table header cell has assigned cells](https://act-rules.github.io/rules/d0f69e). 

The only reliably way of determining how table headers are assigned is in the HTML specification. It is unclear how ARIA table headers are assigned to cells so they are now omitted from the rule.

The update includes changes made in response to [the 1st Task Force feedback](https://www.w3.org/2002/09/wbs/93339/ACTTableHeaders/results) and [the 2nd Task Force feedback](https://docs.google.com/spreadsheets/d/1OSkPFocXk4K3zYLnwS78WLsWO4PvE5yRcsauyefuIUI/edit#gid=1850701681).

Closes #1545 and closes #1517 

Call for review- 2 weeks

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
