### PR TITLE
ARIA state or property is permitted- adding FE4 with aria-checked on a checkbox- 5c01ea

### DIFF
--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -32,14 +32,18 @@ acknowledgments:
 
 ## Applicability
 
-This rule applies to any [WAI-ARIA state or property][] that is specified on an [HTML or SVG element][namespaced element] that is [included in the accessibility tree][].
+This rule applies to any [WAI-ARIA state or property][] that is:
+
+- **namespaced element**: specified on an [HTML or SVG element][namespaced element]; and
+- **perceivable**: the element is [included in the accessibility tree][]; and,
+- **not conflicting**: [WAI-ARIA state or property][] is not specified on an element that has the same [implicit WAI-ARIA semantic](https://www.w3.org/TR/wai-aria-1.2/#implicit_semantics).
 
 ## Expectation 1
 
 For each test target, one of the following is true:
 
 - **global**: the test target is a [global state or property][global]; or
-- **semantic Role**: the test target is an [inherited][], [supported][], or [required][] [state][] or [property][] of the [semantic role][] of the element on which the test target is specified; or
+- **semantic role**: the test target is an [inherited][], [supported][], or [required][] [state][] or [property][] of the [semantic role][] of the element on which the test target is specified; or
 - **language feature**: the test target is specified on an [HTML element][namespaced element] and is allowed on that element. Which ARIA states or properties may be used on which element is described in [ARIA in HTML](https://w3c.github.io/html-aria/).
 
 ## Expectation 2

--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -217,13 +217,21 @@ This `div` element is not [included in the accessibility tree][], hence its [WAI
 
 #### Inapplicable Example 3
 
-The `aria-checked` state is the same as the implicit state of the `input type="checkbox"` element.
+The `input type="checkbox"` element has an implicitly determined state that corresponds to the `aria-checked` state.
 
 ```html
 <label>
 	All
 	<input type="checkbox" aria-checked="mixed" />
 </label>
+```
+
+#### Inapplicable Example 4
+
+The `h3` element has an implicitly determined property that corresponds to the `aria-level` property.
+
+```html
+<h1 aria-level="5">Introduction</h1>
 ```
 
 [attribute value]: #attribute-value 'Definition of attribute value'

--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -58,8 +58,6 @@ Implementation of [Presentational Roles Conflict Resolution][] varies from one b
 
 In HTML, there are language features that do not have corresponding implicit WAI-ARIA semantics. As per [ARIA in HTML](https://www.w3.org/TR/html-aria/), those elements can have [global states or properties][global]. Some of those elements can also have [inherited][], [supported][], or [required][] [states][state] or [properties][property] that correspond to a [WAI-ARIA role](https://www.w3.org/TR/wai-aria-1.2/#introroles). For example, the `audio` element has no corresponding ARIA semantics but it can have [inherited][], [supported][], or [required][] [states][state] or [properties][property] of the [`application` role](https://www.w3.org/TR/wai-aria-1.2/#application).
 
-As per the [conflicts with host language semantics](https://www.w3.org/TR/wai-aria-1.2/#host_general_conflict) section of [WAI-ARIA 1.2](https://www.w3.org/TR/wai-aria-1.2/), user agents must ignore [WAI-ARIA state or property][] that have the same [implicit WAI-ARIA semantic](https://www.w3.org/TR/wai-aria-1.2/#implicit_semantics) in order to avoid providing conflicting states and properties to assistive technologies.
-
 Assessing the value of the attribute is out of scope for this rule.
 
 ### Related rules
@@ -193,17 +191,6 @@ The `aria-label` property is [prohibited][] for an element with a `generic` role
 
 ```html
 <div aria-label="Bananas"></div>
-```
-
-#### Failed Example 4
-
-The `aria-checked` state is [prohibited][] for an `input type="checkbox"` element to avoid providing conflicting states.
-
-```html
-<label>
-	<input type="checkbox" aria-checked="mixed" />
-	All
-</label>
 ```
 
 ### Inapplicable

--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -58,6 +58,8 @@ Implementation of [Presentational Roles Conflict Resolution][] varies from one b
 
 In HTML, there are language features that do not have corresponding implicit WAI-ARIA semantics. As per [ARIA in HTML](https://www.w3.org/TR/html-aria/), those elements can have [global states or properties][global]. Some of those elements can also have [inherited][], [supported][], or [required][] [states][state] or [properties][property] that correspond to a [WAI-ARIA role](https://www.w3.org/TR/wai-aria-1.2/#introroles). For example, the `audio` element has no corresponding ARIA semantics but it can have [inherited][], [supported][], or [required][] [states][state] or [properties][property] of the [`application` role](https://www.w3.org/TR/wai-aria-1.2/#application).
 
+As per the [conflicts with host language semantics](https://www.w3.org/TR/wai-aria-1.2/#host_general_conflict) section of [WAI-ARIA 1.2](https://www.w3.org/TR/wai-aria-1.2/), user agents must ignore [WAI-ARIA state or property][] that have the same [implicit WAI-ARIA semantic](https://www.w3.org/TR/wai-aria-1.2/#implicit_semantics) in order to avoid providing conflicting states and properties to assistive technologies.
+
 Assessing the value of the attribute is out of scope for this rule.
 
 ### Related rules
@@ -191,6 +193,17 @@ The `aria-label` property is [prohibited][] for an element with a `generic` role
 
 ```html
 <div aria-label="Bananas"></div>
+```
+
+#### Failed Example 4
+
+The `aria-checked` state is [prohibited][] for an `input type="checkbox"` element to avoid providing conflicting states.
+
+```html
+<label>
+	<input type="checkbox" aria-checked="mixed" />
+	All
+</label>
 ```
 
 ### Inapplicable

--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -215,6 +215,17 @@ This `div` element is not [included in the accessibility tree][], hence its [WAI
 <div role="button" aria-sort="" style="display:none;"></div>
 ```
 
+#### Inapplicable Example 3
+
+The `aria-checked` state is the same as the implicit state of the `input type="checkbox"` element.
+
+```html
+<label>
+	All
+	<input type="checkbox" aria-checked="mixed" />
+</label>
+```
+
 [attribute value]: #attribute-value 'Definition of attribute value'
 [explicit role]: #explicit-role 'Definition of Explicit Role'
 [focusable]: #focusable 'Definition of focusable'


### PR DESCRIPTION
I feel that the added failed example happens quite often out there and it is not commonly understood why the native states override explicit states so I thought that it would be worthing adding a common example. The example is already covered by the "language feature" point of the expectation section so I only added some background information.

Need for Call for Review:
This will not require a Call for Review.

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
