### PR TITLE
Updates to remark-parse@9.0.0 - eliminates vulnerabilities

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,5 @@ jobs:
           node-version: 16
           cache: npm
       - run: |
-          npm cache clean --force
           npm install
           npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,6 @@ jobs:
           node-version: 16
           cache: npm
       - run: |
+          npm cache clean --force
           npm install
           npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
 				"retext-spell": "^3.0.0",
 				"retext-stringify": "^2.0.4",
 				"retext-syntax-urls": "^1.0.2",
-				"unified": "^8.4.2",
+				"unified": "^10.1.2",
 				"unist-util-visit": "^2.0.3",
 				"vfile-reporter": "^6.0.2",
 				"zx": "^5.3.0"
@@ -9864,6 +9864,23 @@
 				"unist-util-position": "^3.0.0"
 			}
 		},
+		"node_modules/retext/node_modules/unified": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
+			"integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+			"dev": true,
+			"dependencies": {
+				"bail": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^2.0.0",
+				"trough": "^1.0.0",
+				"vfile": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -10924,16 +10941,116 @@
 			}
 		},
 		"node_modules/unified": {
-			"version": "8.4.2",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
-			"integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+			"integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
 			"dev": true,
 			"dependencies": {
-				"bail": "^1.0.0",
+				"@types/unist": "^2.0.0",
+				"bail": "^2.0.0",
 				"extend": "^3.0.0",
-				"is-plain-obj": "^2.0.0",
-				"trough": "^1.0.0",
-				"vfile": "^4.0.0"
+				"is-buffer": "^2.0.0",
+				"is-plain-obj": "^4.0.0",
+				"trough": "^2.0.0",
+				"vfile": "^5.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unified/node_modules/bail": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+			"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+			"dev": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/unified/node_modules/is-buffer": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/unified/node_modules/is-plain-obj": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/unified/node_modules/trough": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+			"integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
+			"dev": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/unified/node_modules/unist-util-stringify-position": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+			"integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+			"dev": true,
+			"dependencies": {
+				"@types/unist": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unified/node_modules/vfile": {
+			"version": "5.3.6",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.6.tgz",
+			"integrity": "sha512-ADBsmerdGBs2WYckrLBEmuETSPyTD4TuLxTrw0DvjirxW1ra4ZwkbzG8ndsv3Q57smvHxo677MHaQrY9yxH8cA==",
+			"dev": true,
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"is-buffer": "^2.0.0",
+				"unist-util-stringify-position": "^3.0.0",
+				"vfile-message": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unified/node_modules/vfile-message": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.3.tgz",
+			"integrity": "sha512-0yaU+rj2gKAyEk12ffdSbBfjnnj+b1zqTBv3OQCTn8yEB02bsPizwdBPrLJjHnK+cU9EMMcUnNv938XcZIkmdA==",
+			"dev": true,
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"unist-util-stringify-position": "^3.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -19217,6 +19334,21 @@
 				"retext-latin": "^2.0.0",
 				"retext-stringify": "^2.0.0",
 				"unified": "^8.0.0"
+			},
+			"dependencies": {
+				"unified": {
+					"version": "8.4.2",
+					"resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
+					"integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+					"dev": true,
+					"requires": {
+						"bail": "^1.0.0",
+						"extend": "^3.0.0",
+						"is-plain-obj": "^2.0.0",
+						"trough": "^1.0.0",
+						"vfile": "^4.0.0"
+					}
+				}
 			}
 		},
 		"retext-english": {
@@ -20150,16 +20282,75 @@
 			}
 		},
 		"unified": {
-			"version": "8.4.2",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
-			"integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+			"integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
 			"dev": true,
 			"requires": {
-				"bail": "^1.0.0",
+				"@types/unist": "^2.0.0",
+				"bail": "^2.0.0",
 				"extend": "^3.0.0",
-				"is-plain-obj": "^2.0.0",
-				"trough": "^1.0.0",
-				"vfile": "^4.0.0"
+				"is-buffer": "^2.0.0",
+				"is-plain-obj": "^4.0.0",
+				"trough": "^2.0.0",
+				"vfile": "^5.0.0"
+			},
+			"dependencies": {
+				"bail": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+					"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+					"dev": true
+				},
+				"is-buffer": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+					"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+					"dev": true
+				},
+				"is-plain-obj": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+					"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+					"dev": true
+				},
+				"trough": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+					"integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
+					"dev": true
+				},
+				"unist-util-stringify-position": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+					"integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+					"dev": true,
+					"requires": {
+						"@types/unist": "^2.0.0"
+					}
+				},
+				"vfile": {
+					"version": "5.3.6",
+					"resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.6.tgz",
+					"integrity": "sha512-ADBsmerdGBs2WYckrLBEmuETSPyTD4TuLxTrw0DvjirxW1ra4ZwkbzG8ndsv3Q57smvHxo677MHaQrY9yxH8cA==",
+					"dev": true,
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"is-buffer": "^2.0.0",
+						"unist-util-stringify-position": "^3.0.0",
+						"vfile-message": "^3.0.0"
+					}
+				},
+				"vfile-message": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.3.tgz",
+					"integrity": "sha512-0yaU+rj2gKAyEk12ffdSbBfjnnj+b1zqTBv3OQCTn8yEB02bsPizwdBPrLJjHnK+cU9EMMcUnNv938XcZIkmdA==",
+					"dev": true,
+					"requires": {
+						"@types/unist": "^2.0.0",
+						"unist-util-stringify-position": "^3.0.0"
+					}
+				}
 			}
 		},
 		"union-value": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
 				"retext-spell": "^3.0.0",
 				"retext-stringify": "^2.0.4",
 				"retext-syntax-urls": "^1.0.2",
-				"unified": "^8.4.2",
+				"unified": "^9.2.1",
 				"unist-util-visit": "^2.0.3",
 				"vfile-reporter": "^6.0.2",
 				"zx": "^5.3.0"
@@ -9864,6 +9864,23 @@
 				"unist-util-position": "^3.0.0"
 			}
 		},
+		"node_modules/retext/node_modules/unified": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
+			"integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+			"dev": true,
+			"dependencies": {
+				"bail": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^2.0.0",
+				"trough": "^1.0.0",
+				"vfile": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -10924,13 +10941,14 @@
 			}
 		},
 		"node_modules/unified": {
-			"version": "8.4.2",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
-			"integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-9.2.1.tgz",
+			"integrity": "sha512-juWjuI8Z4xFg8pJbnEZ41b5xjGUWGHqXALmBZ3FC3WX0PIx1CZBIIJ6mXbYMcf6Yw4Fi0rFUTA1cdz/BglbOhA==",
 			"dev": true,
 			"dependencies": {
 				"bail": "^1.0.0",
 				"extend": "^3.0.0",
+				"is-buffer": "^2.0.0",
 				"is-plain-obj": "^2.0.0",
 				"trough": "^1.0.0",
 				"vfile": "^4.0.0"
@@ -10938,6 +10956,29 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unified/node_modules/is-buffer": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/union-value": {
@@ -19217,6 +19258,21 @@
 				"retext-latin": "^2.0.0",
 				"retext-stringify": "^2.0.0",
 				"unified": "^8.0.0"
+			},
+			"dependencies": {
+				"unified": {
+					"version": "8.4.2",
+					"resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
+					"integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+					"dev": true,
+					"requires": {
+						"bail": "^1.0.0",
+						"extend": "^3.0.0",
+						"is-plain-obj": "^2.0.0",
+						"trough": "^1.0.0",
+						"vfile": "^4.0.0"
+					}
+				}
 			}
 		},
 		"retext-english": {
@@ -20150,16 +20206,25 @@
 			}
 		},
 		"unified": {
-			"version": "8.4.2",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
-			"integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-9.2.1.tgz",
+			"integrity": "sha512-juWjuI8Z4xFg8pJbnEZ41b5xjGUWGHqXALmBZ3FC3WX0PIx1CZBIIJ6mXbYMcf6Yw4Fi0rFUTA1cdz/BglbOhA==",
 			"dev": true,
 			"requires": {
 				"bail": "^1.0.0",
 				"extend": "^3.0.0",
+				"is-buffer": "^2.0.0",
 				"is-plain-obj": "^2.0.0",
 				"trough": "^1.0.0",
 				"vfile": "^4.0.0"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+					"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+					"dev": true
+				}
 			}
 		},
 		"union-value": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
 				"retext-spell": "^3.0.0",
 				"retext-stringify": "^2.0.4",
 				"retext-syntax-urls": "^1.0.2",
-				"unified": "^10.1.2",
+				"unified": "^8.4.2",
 				"unist-util-visit": "^2.0.3",
 				"vfile-reporter": "^6.0.2",
 				"zx": "^5.3.0"
@@ -9864,23 +9864,6 @@
 				"unist-util-position": "^3.0.0"
 			}
 		},
-		"node_modules/retext/node_modules/unified": {
-			"version": "8.4.2",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
-			"integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
-			"dev": true,
-			"dependencies": {
-				"bail": "^1.0.0",
-				"extend": "^3.0.0",
-				"is-plain-obj": "^2.0.0",
-				"trough": "^1.0.0",
-				"vfile": "^4.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -10941,116 +10924,16 @@
 			}
 		},
 		"node_modules/unified": {
-			"version": "10.1.2",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
-			"integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
+			"integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
 			"dev": true,
 			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"bail": "^2.0.0",
+				"bail": "^1.0.0",
 				"extend": "^3.0.0",
-				"is-buffer": "^2.0.0",
-				"is-plain-obj": "^4.0.0",
-				"trough": "^2.0.0",
-				"vfile": "^5.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unified/node_modules/bail": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
-			"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/unified/node_modules/is-buffer": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/unified/node_modules/is-plain-obj": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/unified/node_modules/trough": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
-			"integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/unified/node_modules/unist-util-stringify-position": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
-			"integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
-			"dev": true,
-			"dependencies": {
-				"@types/unist": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unified/node_modules/vfile": {
-			"version": "5.3.6",
-			"resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.6.tgz",
-			"integrity": "sha512-ADBsmerdGBs2WYckrLBEmuETSPyTD4TuLxTrw0DvjirxW1ra4ZwkbzG8ndsv3Q57smvHxo677MHaQrY9yxH8cA==",
-			"dev": true,
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"is-buffer": "^2.0.0",
-				"unist-util-stringify-position": "^3.0.0",
-				"vfile-message": "^3.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unified/node_modules/vfile-message": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.3.tgz",
-			"integrity": "sha512-0yaU+rj2gKAyEk12ffdSbBfjnnj+b1zqTBv3OQCTn8yEB02bsPizwdBPrLJjHnK+cU9EMMcUnNv938XcZIkmdA==",
-			"dev": true,
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"unist-util-stringify-position": "^3.0.0"
+				"is-plain-obj": "^2.0.0",
+				"trough": "^1.0.0",
+				"vfile": "^4.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -19334,21 +19217,6 @@
 				"retext-latin": "^2.0.0",
 				"retext-stringify": "^2.0.0",
 				"unified": "^8.0.0"
-			},
-			"dependencies": {
-				"unified": {
-					"version": "8.4.2",
-					"resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
-					"integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
-					"dev": true,
-					"requires": {
-						"bail": "^1.0.0",
-						"extend": "^3.0.0",
-						"is-plain-obj": "^2.0.0",
-						"trough": "^1.0.0",
-						"vfile": "^4.0.0"
-					}
-				}
 			}
 		},
 		"retext-english": {
@@ -20282,75 +20150,16 @@
 			}
 		},
 		"unified": {
-			"version": "10.1.2",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
-			"integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
+			"integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
 			"dev": true,
 			"requires": {
-				"@types/unist": "^2.0.0",
-				"bail": "^2.0.0",
+				"bail": "^1.0.0",
 				"extend": "^3.0.0",
-				"is-buffer": "^2.0.0",
-				"is-plain-obj": "^4.0.0",
-				"trough": "^2.0.0",
-				"vfile": "^5.0.0"
-			},
-			"dependencies": {
-				"bail": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
-					"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
-					"dev": true
-				},
-				"is-buffer": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-					"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-					"dev": true
-				},
-				"is-plain-obj": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-					"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-					"dev": true
-				},
-				"trough": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
-					"integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
-					"dev": true
-				},
-				"unist-util-stringify-position": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
-					"integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
-					"dev": true,
-					"requires": {
-						"@types/unist": "^2.0.0"
-					}
-				},
-				"vfile": {
-					"version": "5.3.6",
-					"resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.6.tgz",
-					"integrity": "sha512-ADBsmerdGBs2WYckrLBEmuETSPyTD4TuLxTrw0DvjirxW1ra4ZwkbzG8ndsv3Q57smvHxo677MHaQrY9yxH8cA==",
-					"dev": true,
-					"requires": {
-						"@types/unist": "^2.0.0",
-						"is-buffer": "^2.0.0",
-						"unist-util-stringify-position": "^3.0.0",
-						"vfile-message": "^3.0.0"
-					}
-				},
-				"vfile-message": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.3.tgz",
-					"integrity": "sha512-0yaU+rj2gKAyEk12ffdSbBfjnnj+b1zqTBv3OQCTn8yEB02bsPizwdBPrLJjHnK+cU9EMMcUnNv938XcZIkmdA==",
-					"dev": true,
-					"requires": {
-						"@types/unist": "^2.0.0",
-						"unist-util-stringify-position": "^3.0.0"
-					}
-				}
+				"is-plain-obj": "^2.0.0",
+				"trough": "^1.0.0",
+				"vfile": "^4.0.0"
 			}
 		},
 		"union-value": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"moment": "^2.29.4",
 				"prettier": "^1.19.1",
 				"remark-frontmatter": "^1.3.2",
-				"remark-parse": "^8.0.3",
+				"remark-parse": "^9.0.0",
 				"remove-markdown": "^0.3.0",
 				"retext": "^7.0.1",
 				"retext-english": "^3.0.4",
@@ -1972,19 +1972,6 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
-		"node_modules/act-tools/node_modules/remark-parse": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
-			"integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
-			"dev": true,
-			"dependencies": {
-				"mdast-util-from-markdown": "^0.8.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/act-tools/node_modules/unified": {
 			"version": "9.2.2",
 			"resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
@@ -2906,16 +2893,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/collapse-white-space": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
-			"integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/collect-v8-coverage": {
@@ -5004,16 +4981,6 @@
 			"integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
 			"dev": true
 		},
-		"node_modules/is-whitespace-character": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
-			"integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -5021,16 +4988,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-word-character": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
-			"integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/isarray": {
@@ -8344,16 +8301,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/markdown-escapes": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
-			"integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/markdown-table": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
@@ -9538,27 +9485,12 @@
 			}
 		},
 		"node_modules/remark-parse": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.3.tgz",
-			"integrity": "sha512-E1K9+QLGgggHxCQtLt++uXltxEprmWzNfg+MxpfHsZlrddKzZ/hZyWHDbK3/Ap8HJQqYJRXP+jHczdL6q6i85Q==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+			"integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
 			"dev": true,
 			"dependencies": {
-				"ccount": "^1.0.0",
-				"collapse-white-space": "^1.0.2",
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-whitespace-character": "^1.0.0",
-				"is-word-character": "^1.0.0",
-				"markdown-escapes": "^1.0.0",
-				"parse-entities": "^2.0.0",
-				"repeat-string": "^1.5.4",
-				"state-toggle": "^1.0.0",
-				"trim": "0.0.1",
-				"trim-trailing-lines": "^1.0.0",
-				"unherit": "^1.0.4",
-				"unist-util-remove-position": "^2.0.0",
-				"vfile-location": "^3.0.0",
-				"xtend": "^4.0.1"
+				"mdast-util-from-markdown": "^0.8.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -10443,16 +10375,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/state-toggle": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
-			"integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -10843,22 +10765,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/trim": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-			"integrity": "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==",
-			"dev": true
-		},
-		"node_modules/trim-trailing-lines": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz",
-			"integrity": "sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/trough": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
@@ -11102,19 +11008,6 @@
 			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
 			"integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==",
 			"dev": true,
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-remove-position": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-2.0.1.tgz",
-			"integrity": "sha512-fDZsLYIe2uT+oGFnuZmy73K6ZxOPG/Qcm+w7jbEjaFcJgbQ6cqjs/eSPzXhsmGpAsWPkqZM9pYjww5QTn3LHMA==",
-			"dev": true,
-			"dependencies": {
-				"unist-util-visit": "^2.0.0"
-			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
@@ -11380,16 +11273,6 @@
 				"unist-util-stringify-position": "^2.0.0",
 				"vfile-message": "^2.0.0"
 			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/vfile-location": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.2.0.tgz",
-			"integrity": "sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA==",
-			"dev": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
@@ -13427,15 +13310,6 @@
 						"micromark-extension-frontmatter": "^0.2.0"
 					}
 				},
-				"remark-parse": {
-					"version": "9.0.0",
-					"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
-					"integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
-					"dev": true,
-					"requires": {
-						"mdast-util-from-markdown": "^0.8.0"
-					}
-				},
 				"unified": {
 					"version": "9.2.2",
 					"resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
@@ -14129,12 +14003,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"dev": true
-		},
-		"collapse-white-space": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
-			"integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
 			"dev": true
 		},
 		"collect-v8-coverage": {
@@ -15741,22 +15609,10 @@
 			"integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
 			"dev": true
 		},
-		"is-whitespace-character": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
-			"integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
-			"dev": true
-		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-			"dev": true
-		},
-		"is-word-character": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
-			"integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
 			"dev": true
 		},
 		"isarray": {
@@ -18268,12 +18124,6 @@
 				"object-visit": "^1.0.0"
 			}
 		},
-		"markdown-escapes": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
-			"integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
-			"dev": true
-		},
 		"markdown-table": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
@@ -19170,27 +19020,12 @@
 			}
 		},
 		"remark-parse": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.3.tgz",
-			"integrity": "sha512-E1K9+QLGgggHxCQtLt++uXltxEprmWzNfg+MxpfHsZlrddKzZ/hZyWHDbK3/Ap8HJQqYJRXP+jHczdL6q6i85Q==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+			"integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
 			"dev": true,
 			"requires": {
-				"ccount": "^1.0.0",
-				"collapse-white-space": "^1.0.2",
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-whitespace-character": "^1.0.0",
-				"is-word-character": "^1.0.0",
-				"markdown-escapes": "^1.0.0",
-				"parse-entities": "^2.0.0",
-				"repeat-string": "^1.5.4",
-				"state-toggle": "^1.0.0",
-				"trim": "0.0.1",
-				"trim-trailing-lines": "^1.0.0",
-				"unherit": "^1.0.4",
-				"unist-util-remove-position": "^2.0.0",
-				"vfile-location": "^3.0.0",
-				"xtend": "^4.0.1"
+				"mdast-util-from-markdown": "^0.8.0"
 			}
 		},
 		"remark-rehype": {
@@ -19902,12 +19737,6 @@
 				}
 			}
 		},
-		"state-toggle": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
-			"integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
-			"dev": true
-		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -20212,18 +20041,6 @@
 				"punycode": "^2.1.1"
 			}
 		},
-		"trim": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-			"integrity": "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==",
-			"dev": true
-		},
-		"trim-trailing-lines": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz",
-			"integrity": "sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==",
-			"dev": true
-		},
 		"trough": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
@@ -20398,15 +20215,6 @@
 			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
 			"integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==",
 			"dev": true
-		},
-		"unist-util-remove-position": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-2.0.1.tgz",
-			"integrity": "sha512-fDZsLYIe2uT+oGFnuZmy73K6ZxOPG/Qcm+w7jbEjaFcJgbQ6cqjs/eSPzXhsmGpAsWPkqZM9pYjww5QTn3LHMA==",
-			"dev": true,
-			"requires": {
-				"unist-util-visit": "^2.0.0"
-			}
 		},
 		"unist-util-stringify-position": {
 			"version": "2.0.3",
@@ -20616,12 +20424,6 @@
 					"dev": true
 				}
 			}
-		},
-		"vfile-location": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.2.0.tgz",
-			"integrity": "sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA==",
-			"dev": true
 		},
 		"vfile-message": {
 			"version": "2.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"moment": "^2.29.4",
 				"prettier": "^1.19.1",
 				"remark-frontmatter": "^1.3.2",
-				"remark-parse": "^9.0.0",
+				"remark-parse": "^8.0.3",
 				"remove-markdown": "^0.3.0",
 				"retext": "^7.0.1",
 				"retext-english": "^3.0.4",
@@ -1972,6 +1972,19 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/act-tools/node_modules/remark-parse": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+			"integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+			"dev": true,
+			"dependencies": {
+				"mdast-util-from-markdown": "^0.8.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/act-tools/node_modules/unified": {
 			"version": "9.2.2",
 			"resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
@@ -2893,6 +2906,16 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/collapse-white-space": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
+			"integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
+			"dev": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/collect-v8-coverage": {
@@ -4981,6 +5004,16 @@
 			"integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
 			"dev": true
 		},
+		"node_modules/is-whitespace-character": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
+			"integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
+			"dev": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -4988,6 +5021,16 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-word-character": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
+			"integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
+			"dev": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/isarray": {
@@ -8301,6 +8344,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/markdown-escapes": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
+			"integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
+			"dev": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/markdown-table": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
@@ -9485,12 +9538,27 @@
 			}
 		},
 		"node_modules/remark-parse": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
-			"integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.3.tgz",
+			"integrity": "sha512-E1K9+QLGgggHxCQtLt++uXltxEprmWzNfg+MxpfHsZlrddKzZ/hZyWHDbK3/Ap8HJQqYJRXP+jHczdL6q6i85Q==",
 			"dev": true,
 			"dependencies": {
-				"mdast-util-from-markdown": "^0.8.0"
+				"ccount": "^1.0.0",
+				"collapse-white-space": "^1.0.2",
+				"is-alphabetical": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-whitespace-character": "^1.0.0",
+				"is-word-character": "^1.0.0",
+				"markdown-escapes": "^1.0.0",
+				"parse-entities": "^2.0.0",
+				"repeat-string": "^1.5.4",
+				"state-toggle": "^1.0.0",
+				"trim": "0.0.1",
+				"trim-trailing-lines": "^1.0.0",
+				"unherit": "^1.0.4",
+				"unist-util-remove-position": "^2.0.0",
+				"vfile-location": "^3.0.0",
+				"xtend": "^4.0.1"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -10375,6 +10443,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/state-toggle": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
+			"integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
+			"dev": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -10765,6 +10843,22 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/trim": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+			"integrity": "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==",
+			"dev": true
+		},
+		"node_modules/trim-trailing-lines": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz",
+			"integrity": "sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==",
+			"dev": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/trough": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
@@ -11008,6 +11102,19 @@
 			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
 			"integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==",
 			"dev": true,
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-remove-position": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-2.0.1.tgz",
+			"integrity": "sha512-fDZsLYIe2uT+oGFnuZmy73K6ZxOPG/Qcm+w7jbEjaFcJgbQ6cqjs/eSPzXhsmGpAsWPkqZM9pYjww5QTn3LHMA==",
+			"dev": true,
+			"dependencies": {
+				"unist-util-visit": "^2.0.0"
+			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
@@ -11273,6 +11380,16 @@
 				"unist-util-stringify-position": "^2.0.0",
 				"vfile-message": "^2.0.0"
 			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/vfile-location": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.2.0.tgz",
+			"integrity": "sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA==",
+			"dev": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
@@ -13310,6 +13427,15 @@
 						"micromark-extension-frontmatter": "^0.2.0"
 					}
 				},
+				"remark-parse": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+					"integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+					"dev": true,
+					"requires": {
+						"mdast-util-from-markdown": "^0.8.0"
+					}
+				},
 				"unified": {
 					"version": "9.2.2",
 					"resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
@@ -14003,6 +14129,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
+		},
+		"collapse-white-space": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
+			"integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
 			"dev": true
 		},
 		"collect-v8-coverage": {
@@ -15609,10 +15741,22 @@
 			"integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
 			"dev": true
 		},
+		"is-whitespace-character": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
+			"integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
+			"dev": true
+		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
+		},
+		"is-word-character": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
+			"integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
 			"dev": true
 		},
 		"isarray": {
@@ -18124,6 +18268,12 @@
 				"object-visit": "^1.0.0"
 			}
 		},
+		"markdown-escapes": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
+			"integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
+			"dev": true
+		},
 		"markdown-table": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
@@ -19020,12 +19170,27 @@
 			}
 		},
 		"remark-parse": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
-			"integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.3.tgz",
+			"integrity": "sha512-E1K9+QLGgggHxCQtLt++uXltxEprmWzNfg+MxpfHsZlrddKzZ/hZyWHDbK3/Ap8HJQqYJRXP+jHczdL6q6i85Q==",
 			"dev": true,
 			"requires": {
-				"mdast-util-from-markdown": "^0.8.0"
+				"ccount": "^1.0.0",
+				"collapse-white-space": "^1.0.2",
+				"is-alphabetical": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-whitespace-character": "^1.0.0",
+				"is-word-character": "^1.0.0",
+				"markdown-escapes": "^1.0.0",
+				"parse-entities": "^2.0.0",
+				"repeat-string": "^1.5.4",
+				"state-toggle": "^1.0.0",
+				"trim": "0.0.1",
+				"trim-trailing-lines": "^1.0.0",
+				"unherit": "^1.0.4",
+				"unist-util-remove-position": "^2.0.0",
+				"vfile-location": "^3.0.0",
+				"xtend": "^4.0.1"
 			}
 		},
 		"remark-rehype": {
@@ -19737,6 +19902,12 @@
 				}
 			}
 		},
+		"state-toggle": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
+			"integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
+			"dev": true
+		},
 		"static-extend": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -20041,6 +20212,18 @@
 				"punycode": "^2.1.1"
 			}
 		},
+		"trim": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+			"integrity": "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==",
+			"dev": true
+		},
+		"trim-trailing-lines": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz",
+			"integrity": "sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==",
+			"dev": true
+		},
 		"trough": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
@@ -20215,6 +20398,15 @@
 			"resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
 			"integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==",
 			"dev": true
+		},
+		"unist-util-remove-position": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-2.0.1.tgz",
+			"integrity": "sha512-fDZsLYIe2uT+oGFnuZmy73K6ZxOPG/Qcm+w7jbEjaFcJgbQ6cqjs/eSPzXhsmGpAsWPkqZM9pYjww5QTn3LHMA==",
+			"dev": true,
+			"requires": {
+				"unist-util-visit": "^2.0.0"
+			}
 		},
 		"unist-util-stringify-position": {
 			"version": "2.0.3",
@@ -20424,6 +20616,12 @@
 					"dev": true
 				}
 			}
+		},
+		"vfile-location": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.2.0.tgz",
+			"integrity": "sha512-aLEIZKv/oxuCDZ8lkJGhuhztf/BW4M+iHdCwglA/eWc+vtuRFJj8EtgceYFX4LRjOhCAAiNHsKGssC6onJ+jbA==",
+			"dev": true
 		},
 		"vfile-message": {
 			"version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
 		"moment": "^2.29.4",
 		"prettier": "^1.19.1",
 		"remark-frontmatter": "^1.3.2",
-		"remark-parse": "^9.0.0",
+		"remark-parse": "^8.0.3",
 		"remove-markdown": "^0.3.0",
 		"retext": "^7.0.1",
 		"retext-english": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
 		"retext-spell": "^3.0.0",
 		"retext-stringify": "^2.0.4",
 		"retext-syntax-urls": "^1.0.2",
-		"unified": "^8.4.2",
+		"unified": "^9.2.1",
 		"unist-util-visit": "^2.0.3",
 		"vfile-reporter": "^6.0.2",
 		"zx": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
 		"retext-spell": "^3.0.0",
 		"retext-stringify": "^2.0.4",
 		"retext-syntax-urls": "^1.0.2",
-		"unified": "^8.4.2",
+		"unified": "^10.1.2",
 		"unist-util-visit": "^2.0.3",
 		"vfile-reporter": "^6.0.2",
 		"zx": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
 		"retext-spell": "^3.0.0",
 		"retext-stringify": "^2.0.4",
 		"retext-syntax-urls": "^1.0.2",
-		"unified": "^10.1.2",
+		"unified": "^8.4.2",
 		"unist-util-visit": "^2.0.3",
 		"vfile-reporter": "^6.0.2",
 		"zx": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
 		"moment": "^2.29.4",
 		"prettier": "^1.19.1",
 		"remark-frontmatter": "^1.3.2",
-		"remark-parse": "^8.0.3",
+		"remark-parse": "^9.0.0",
 		"remove-markdown": "^0.3.0",
 		"retext": "^7.0.1",
 		"retext-english": "^3.0.4",


### PR DESCRIPTION
Running `npm install` returns a high severity issue for the _remark-parse_ dependancy that relies on _trim_. This PR updates the package.json and package-lock.json to _remark-parse@9.0.0_ which eliminates the issue.

Currently it is not possible to update _remark-parse_ to 10.0.1 as it's an ECMASript module and a bit more work would be required to run the tests.

Need for Call for Review:
This will not require a Call for Review

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
