### PR TITLE
Add more secondary requirements

### DIFF
--- a/__tests__/frontmatter.js
+++ b/__tests__/frontmatter.js
@@ -1,6 +1,5 @@
 const describeRule = require('../test-utils/describe-rule')
 const describePage = require('../test-utils/describe-page')
-const getMarkdownAstNodesOfType = require('../utils/get-markdown-ast-nodes-of-type')
 
 describe('frontmatter', () => {
 	/**
@@ -96,6 +95,11 @@ function validateRuleFrontmatter({ frontmatter }, metaData) {
 		 */
 		const accRequirementValues = Object.values(accessibility_requirements)
 		test.each(accRequirementValues)('has expected keys for accessibility requirement: `%p`', accReq => {
+			if (accReq[secondary]) {
+				expect(accReq[secondary]).toBeTrue()
+				return
+			}
+
 			const keys = Object.keys(accReq).sort()
 			expect(keys.length).toBeGreaterThanOrEqual(4)
 			expect(keys).toIncludeAllMembers(['failed', 'forConformance', 'inapplicable', 'passed'])

--- a/__tests__/frontmatter.js
+++ b/__tests__/frontmatter.js
@@ -95,8 +95,8 @@ function validateRuleFrontmatter({ frontmatter }, metaData) {
 		 */
 		const accRequirementValues = Object.values(accessibility_requirements)
 		test.each(accRequirementValues)('has expected keys for accessibility requirement: `%p`', accReq => {
-			if (accReq[secondary]) {
-				expect(accReq[secondary]).toBeTrue()
+			if (accReq.secondary) {
+				expect(accReq.secondary).toBeTrue()
 				return
 			}
 

--- a/_rules/aria-attr-defined-5f99a7.md
+++ b/_rules/aria-attr-defined-5f99a7.md
@@ -5,6 +5,10 @@ rule_type: atomic
 description: |
   This rule checks that each `aria-` attribute specified is defined in ARIA 1.2.
 accessibility_requirements:
+  wcag20:1.3.1: # Info and Relationships (A)
+    secondary: true
+  wcag20:4.1.2: # Name, Role, Value (A)
+    secondary: true
 input_aspects:
   - DOM Tree
 acknowledgments:
@@ -32,9 +36,14 @@ There are no accessibility support issues known.
 
 ## Background
 
+The presence of unknown ARIA attributes is often the result of a typo or other developer error. These attributes are ignored by browsers and other assistive technologies. This often means that a state or property should exist does not. This can cause issues under [success criterion 1.3.1 Info and Relationships][sc131] or [4.1.2 Name, Rule Value][sc412].
+
+### Bibliography
+
 - [ARIA in HTML](https://www.w3.org/TR/html-aria/#index-aria-global)
 - [WAI ARIA Supported States and Properties](https://www.w3.org/TR/wai-aria-1.2/#supportedState)
 - [G108: Using markup features to expose the name and role](https://www.w3.org/WAI/WCAG21/Techniques/general/G108)
+- [Understanding Success Criterion 1.3.1: Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)
 - [Understanding Success Criterion 4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)
 - [Semantics and ARIA](https://developers.google.com/web/fundamentals/accessibility/semantics-aria/)
 
@@ -123,3 +132,5 @@ This `canvas` element does not have an `aria-*` attribute specified.
 ```
 
 [wai-aria specifications]: #wai-aria-specifications 'Definition of WAI-ARIA specifications'
+[sc131]: https://www.w3.org/TR/WCAG21/#info-and-relationships
+[sc412]: https://www.w3.org/TR/WCAG21/#name-role-value

--- a/_rules/aria-attr-defined-5f99a7.md
+++ b/_rules/aria-attr-defined-5f99a7.md
@@ -36,7 +36,7 @@ There are no accessibility support issues known.
 
 ## Background
 
-The presence of unknown ARIA attributes is often the result of a typo or other developer error. These attributes are ignored by browsers and other assistive technologies. This often means that a state or property should exist does not. This can cause issues under [success criterion 1.3.1 Info and Relationships][sc131] or [4.1.2 Name, Rule Value][sc412].
+The presence of unknown ARIA attributes is often the result of a typo or other developer error. These attributes are ignored by browsers and other assistive technologies. This often means that a state or property which should exist is missing. This can cause issues under [success criterion 1.3.1 Info and Relationships][sc131] or [4.1.2 Name, Rule Value][sc412].
 
 ### Bibliography
 

--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -16,6 +16,10 @@ accessibility_requirements:
     failed: not satisfied
     passed: satisfied
     inapplicable: satisfied
+  wcag20:1.3.1: # Info and Relationships (A)
+    secondary: true
+  wcag20:4.1.2: # Name, Role, Value (A)
+    secondary: true
 input_aspects:
   - Accessibility Tree
   - CSS styling
@@ -55,6 +59,8 @@ There are no assumptions.
 Implementation of [Presentational Roles Conflict Resolution][] varies from one browser or assistive technology to another. Depending on this, some elements can have a [semantic role][] of `none` and their attributes fail this rule with some technologies but users of other technology would not experience any accessibility issue.
 
 ## Background
+
+The presence of prohibited ARIA attributes is often the result of a developer using an incorrect role, or a misunderstanding of the attribute. These attributes are ignored by browsers and other assistive technologies. This often means that a state or property should exist does not. This can cause issues under [success criterion 1.3.1 Info and Relationships][sc131] or [4.1.2 Name, Rule Value][sc412].
 
 In HTML, there are language features that do not have corresponding implicit WAI-ARIA semantics. As per [ARIA in HTML](https://www.w3.org/TR/html-aria/), those elements can have [global states or properties][global]. Some of those elements can also have [inherited][], [supported][], or [required][] [states][state] or [properties][property] that correspond to a [WAI-ARIA role](https://www.w3.org/TR/wai-aria-1.2/#introroles). For example, the `audio` element has no corresponding ARIA semantics but it can have [inherited][], [supported][], or [required][] [states][state] or [properties][property] of the [`application` role](https://www.w3.org/TR/wai-aria-1.2/#application).
 
@@ -227,3 +233,5 @@ This `div` element is not [included in the accessibility tree][], hence its [WAI
 [wai-aria state or property]: https://www.w3.org/TR/wai-aria-1.2/#state_prop_def 'Definition of ARIA States and Properties'
 [namespaced element]: #namespaced-element
 [prohibited]: https://www.w3.org/TR/wai-aria-1.2/#prohibitedattributes 'WAI-ARIA 1.2 Definition of Prohibited States and Properties'
+[sc131]: https://www.w3.org/TR/WCAG21/#info-and-relationships
+[sc412]: https://www.w3.org/TR/WCAG21/#name-role-value

--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -60,7 +60,7 @@ Implementation of [Presentational Roles Conflict Resolution][] varies from one b
 
 ## Background
 
-The presence of prohibited ARIA attributes is often the result of a developer using an incorrect role, or a misunderstanding of the attribute. These attributes are ignored by browsers and other assistive technologies. This often means that a state or property should exist does not. This can cause issues under [success criterion 1.3.1 Info and Relationships][sc131] or [4.1.2 Name, Rule Value][sc412].
+The presence of prohibited ARIA attributes is often the result of a developer using an incorrect role, or a misunderstanding of the attribute. These attributes are ignored by browsers and other assistive technologies. This often means that a state or property which should exist is missing. This can cause issues under [success criterion 1.3.1 Info and Relationships][sc131] or [4.1.2 Name, Rule Value][sc412].
 
 In HTML, there are language features that do not have corresponding implicit WAI-ARIA semantics. As per [ARIA in HTML](https://www.w3.org/TR/html-aria/), those elements can have [global states or properties][global]. Some of those elements can also have [inherited][], [supported][], or [required][] [states][state] or [properties][property] that correspond to a [WAI-ARIA role](https://www.w3.org/TR/wai-aria-1.2/#introroles). For example, the `audio` element has no corresponding ARIA semantics but it can have [inherited][], [supported][], or [required][] [states][state] or [properties][property] of the [`application` role](https://www.w3.org/TR/wai-aria-1.2/#application).
 

--- a/_rules/aria-state-or-property-valid-value-6a7281.md
+++ b/_rules/aria-state-or-property-valid-value-6a7281.md
@@ -11,6 +11,10 @@ accessibility_requirements:
     failed: not satisfied
     passed: satisfied
     inapplicable: satisfied
+  wcag20:1.3.1: # Info and Relationships (A)
+    secondary: true
+  wcag20:4.1.2: # Name, Role, Value (A)
+    secondary: true
 input_aspects:
   - DOM Tree
   - CSS Styling
@@ -43,6 +47,8 @@ This rule catches values that are undefined in [WAI-ARIA Specifications][], and 
 Some user agents treat the value of `aria-*` attribute as case-sensitive (even when these are not ID) while some treat them as case-insensitive.
 
 ## Background
+
+Using invalid ARIA attribute values is often the result of a typo or other developer error. These attributes are then either ignored, or a default value is assumed by browsers and assistive technologies. This often means that a state or property should exist does not. This can cause issues under [success criterion 1.3.1 Info and Relationships][sc131] or [4.1.2 Name, Rule Value][sc412].
 
 Only for [WAI-ARIA required properties](https://www.w3.org/TR/wai-aria-1.2/#requiredState) with value types `ID Reference` and `ID Reference List` is there a requirement that the elements with the given ids actually exists. For non-required properties, this is not a requirement. For example, the value of the `aria-errormessage` attribute on an `input` does not need to reference an `id` that exists within the same document, because an [HTML element](https://html.spec.whatwg.org/#htmlelement) with such and `id` may be created in response to an [event](https://dom.spec.whatwg.org/#event) that may or may not happen.
 
@@ -284,3 +290,5 @@ Element has ARIA role, but no ARIA states or properties
 
 [wai-aria specifications]: #wai-aria-specifications 'List of WAI-ARIA Specifications'
 [html or svg element]: #namespaced-element
+[sc131]: https://www.w3.org/TR/WCAG21/#info-and-relationships
+[sc412]: https://www.w3.org/TR/WCAG21/#name-role-value

--- a/_rules/aria-state-or-property-valid-value-6a7281.md
+++ b/_rules/aria-state-or-property-valid-value-6a7281.md
@@ -48,7 +48,7 @@ Some user agents treat the value of `aria-*` attribute as case-sensitive (even w
 
 ## Background
 
-Using invalid ARIA attribute values is often the result of a typo or other developer error. These attributes are then either ignored, or a default value is assumed by browsers and assistive technologies. This often means that a state or property should exist does not. This can cause issues under [success criterion 1.3.1 Info and Relationships][sc131] or [4.1.2 Name, Rule Value][sc412].
+Using invalid ARIA attribute values is often the result of a typo or other developer error. These attributes are then either ignored, or a default value is assumed by browsers and assistive technologies. This often means that a state or property which should exist is missing. This can cause issues under [success criterion 1.3.1 Info and Relationships][sc131] or [4.1.2 Name, Rule Value][sc412].
 
 Only for [WAI-ARIA required properties](https://www.w3.org/TR/wai-aria-1.2/#requiredState) with value types `ID Reference` and `ID Reference List` is there a requirement that the elements with the given ids actually exists. For non-required properties, this is not a requirement. For example, the value of the `aria-errormessage` attribute on an `input` does not need to reference an `id` that exists within the same document, because an [HTML element](https://html.spec.whatwg.org/#htmlelement) with such and `id` may be created in response to an [event](https://dom.spec.whatwg.org/#event) that may or may not happen.
 

--- a/_rules/aria-state-or-property-valid-value-6a7281.md
+++ b/_rules/aria-state-or-property-valid-value-6a7281.md
@@ -48,7 +48,7 @@ Some user agents treat the value of `aria-*` attribute as case-sensitive (even w
 
 ## Background
 
-Using invalid ARIA attribute values is often the result of a typo or other developer error. These attributes are then either ignored, or a default value is assumed by browsers and assistive technologies. This often means that a state or property which should exist is missing. This can cause issues under [success criterion 1.3.1 Info and Relationships][sc131] or [4.1.2 Name, Rule Value][sc412].
+Using invalid ARIA attribute values is often the result of a typo or other developer error. These attributes are then either ignored, or a default value is assumed by browsers and assistive technologies. This often means that a state or property which should exist is missing or has an unexpected value. This can cause issues under [success criterion 1.3.1 Info and Relationships][sc131] or [4.1.2 Name, Rule Value][sc412].
 
 Only for [WAI-ARIA required properties](https://www.w3.org/TR/wai-aria-1.2/#requiredState) with value types `ID Reference` and `ID Reference List` is there a requirement that the elements with the given ids actually exists. For non-required properties, this is not a requirement. For example, the value of the `aria-errormessage` attribute on an `input` does not need to reference an `id` that exists within the same document, because an [HTML element](https://html.spec.whatwg.org/#htmlelement) with such and `id` may be created in response to an [event](https://dom.spec.whatwg.org/#event) that may or may not happen.
 

--- a/_rules/link-non-empty-accessible-name-c487ae.md
+++ b/_rules/link-non-empty-accessible-name-c487ae.md
@@ -66,7 +66,7 @@ The rule assumes that all links are [user interface components](https://www.w3.o
 
 ## Background
 
-The HTML `area` element is both a link and an non-text content. When this rule fails on `area` elements, [success criterion 1.1.1 Non-text content][sc111] is not satisfied.
+The HTML `area` element is both a link and an non-text content. When this rule fails on `area` elements [success criterion 1.1.1 Non-text content][sc111] is not satisfied.
 
 ### Related rules
 

--- a/_rules/link-non-empty-accessible-name-c487ae.md
+++ b/_rules/link-non-empty-accessible-name-c487ae.md
@@ -26,6 +26,8 @@ accessibility_requirements:
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
+  wcag20:1.1.1: # Non-text content (A)
+    secondary: true
 input_aspects:
   - Accessibility Tree
   - DOM Tree
@@ -63,6 +65,8 @@ The rule assumes that all links are [user interface components](https://www.w3.o
 - Accessibility support for some elements inheriting the semantic role of `link` (e.g. elements with `doc-*` attributes) may vary depending on the assistive technology in use.
 
 ## Background
+
+The HTML `area` element is both a link and an non-text content. When this rule fails on `area` elements, [success criterion 1.1.1 Non-text content][sc111] is not satisfied.
 
 ### Related rules
 
@@ -361,3 +365,4 @@ This `a` element does not have the role of link because it does not have an `hre
 [semantic role]: #semantic-role 'Definition of Semantic Role'
 [attribute value]: #attribute-value 'Definition of Attribute value'
 [html element]: #namespaced-element
+[sc111]: https://www.w3.org/TR/WCAG21/#non-text-content

--- a/_rules/link-non-empty-accessible-name-c487ae.md
+++ b/_rules/link-non-empty-accessible-name-c487ae.md
@@ -66,7 +66,7 @@ The rule assumes that all links are [user interface components](https://www.w3.o
 
 ## Background
 
-The HTML `area` element is both a link and an non-text content. When this rule fails on `area` elements [success criterion 1.1.1 Non-text content][sc111] is not satisfied.
+The HTML `area` element is both a link and non-text content. When this rule fails on `area` elements [success criterion 1.1.1 Non-text content][sc111] is not satisfied.
 
 ### Related rules
 

--- a/_rules/meta-refresh-no-delay-no-exception-bisz58.md
+++ b/_rules/meta-refresh-no-delay-no-exception-bisz58.md
@@ -25,6 +25,8 @@ accessibility_requirements:
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
+  wcag20:2.2.1: # Timing Adjustable (A)
+    secondary: True
 input_aspects:
   - DOM Tree
 acknowledgments:
@@ -60,6 +62,8 @@ Not all major web browsers parse the value of the `content` attribute in the sam
 ## Background
 
 Because a refresh with a timing of 0 is a redirect, it is exempt from this rule. Since this can cause rapid screen flashes it is strongly recommended to avoid this.
+
+This rule is closely related to [success criterion 2.2.1 Time Adjustable][sc221]. Because this rule is stricter, `meta` elements that passes this rule satisfy 2.1.1 Time Adjustable.
 
 ### Bibliography
 
@@ -214,3 +218,4 @@ This `meta` element has an invalid `content` attribute, and is therefore inappli
 [attribute value]: #attribute-value 'Definition of Attribute Value'
 [meta refresh]: https://html.spec.whatwg.org/#attr-meta-http-equiv-refresh 'HTML specification of the meta refresh State'
 [shared declarative refresh steps]: https://html.spec.whatwg.org/#shared-declarative-refresh-steps 'HTML specification of the Shared Declarative Refresh Steps'
+[sc221]: https://www.w3.org/TR/WCAG21/#timing-adjustable

--- a/_rules/meta-refresh-no-delay-no-exception-bisz58.md
+++ b/_rules/meta-refresh-no-delay-no-exception-bisz58.md
@@ -63,7 +63,7 @@ Not all major web browsers parse the value of the `content` attribute in the sam
 
 Because a refresh with a timing of 0 is a redirect, it is exempt from this rule. Since this can cause rapid screen flashes it is strongly recommended to avoid this.
 
-This rule is closely related to [success criterion 2.2.1 Time Adjustable][sc221]. Because this rule is stricter, `meta` elements that passes this rule satisfy 2.1.1 Time Adjustable.
+This rule is closely related to [success criterion 2.2.1 Time Adjustable][sc221]. Because this rule is stricter, `meta` elements that pass this rule satisfy 2.1.1 Time Adjustable.
 
 ### Bibliography
 

--- a/_rules/role-attribute-valid-value-674b10.md
+++ b/_rules/role-attribute-valid-value-674b10.md
@@ -5,11 +5,6 @@ rule_type: atomic
 description: |
   This rule checks that each `role` attribute has a valid value.
 accessibility_requirements:
-  wcag20:1.3.1: # Info and Relationship (A)
-    forConformance: true
-    failed: not satisfied
-    passed: further testing needed
-    inapplicable: further testing needed
   wcag-technique:ARIA4: # Using a WAI-ARIA role to expose the role of a user interface component
     forConformance: false
     failed: not satisfied
@@ -20,6 +15,10 @@ accessibility_requirements:
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
+  wcag20:1.3.1: # Info and Relationship (A)
+    secondary: true
+  wcag20:4.1.2: # Name, Role, Value (A)
+    secondary: true
 input_aspects:
   - DOM Tree
   - CSS Styling
@@ -52,6 +51,8 @@ Each test target has at least one token which is a valid value corresponding to 
 Older browsers do not support more than one token in the value for a role attribute. If multiple values are used in the role attribute, the attribute is ignored in these browsers.
 
 ## Background
+
+Using an invalid role is often the result of a typo or other developer error. Such roles are ignored by browsers and assistive technologies, and the element's default semantics is used. This often means that role that should exist does not. This can cause issues under [success criterion 1.3.1 Info and Relationships][sc131] or [4.1.2 Name, Rule Value][sc412].
 
 The `role` attribute is a set of [space separated tokens][]. Having a [whitespace](#whitespace) separated list of more than one token in the value of the role attribute is used for what is known as _fallback roles_. If the first token is not accessibility supported (or valid), the next one will be used for determining the [semantic role][] of the element, and so forth. Having the rule target attributes containing at least one non-[ASCII whitespace][] character ensures that there is at least one token in the set.
 
@@ -186,3 +187,5 @@ This `role` attribute is specified on an element which is [programmatically hidd
 [space separated tokens]: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#space-separated-tokens 'Definition of space separated tokens'
 [wai-aria role]: https://www.w3.org/TR/wai-aria-1.2/#role_definitions 'List of WAI-ARIA roles'
 [wai-aria specifications]: #wai-aria-specifications 'Definition of WAI-ARIA Specifications'
+[sc131]: https://www.w3.org/TR/WCAG21/#info-and-relationships
+[sc412]: https://www.w3.org/TR/WCAG21/#name-role-value

--- a/_rules/role-attribute-valid-value-674b10.md
+++ b/_rules/role-attribute-valid-value-674b10.md
@@ -52,7 +52,7 @@ Older browsers do not support more than one token in the value for a role attrib
 
 ## Background
 
-Using an invalid role is often the result of a typo or other developer error. Such roles are ignored by browsers and assistive technologies, and the element's default semantics is used. This often means that role that should exist does not. This can cause issues under [success criterion 1.3.1 Info and Relationships][sc131] or [4.1.2 Name, Rule Value][sc412].
+Using an invalid role is often the result of a typo or other developer error. Such roles are ignored by browsers and assistive technologies, and the element's default semantics is used. This often means that a role that should exist is missing. This can cause issues under [success criterion 1.3.1 Info and Relationships][sc131] or [4.1.2 Name, Rule Value][sc412].
 
 The `role` attribute is a set of [space separated tokens][]. Having a [whitespace](#whitespace) separated list of more than one token in the value of the role attribute is used for what is known as _fallback roles_. If the first token is not accessibility supported (or valid), the next one will be used for determining the [semantic role][] of the element, and so forth. Having the rule target attributes containing at least one non-[ASCII whitespace][] character ensures that there is at least one token in the set.
 

--- a/_rules/role-attribute-valid-value-674b10.md
+++ b/_rules/role-attribute-valid-value-674b10.md
@@ -44,7 +44,7 @@ Each test target has at least one token which is a valid value corresponding to 
 
 - This rule assumes that the `role` attribute is used to provide an ARIA [semantic role][] to the elements. If it is used for other purposes, this rule shouldn't be used.
 - This rule assumes that elements with a `role` attribute have their intended structure and relationship conveyed through some sort of presentation. If it is not the case, it is possible to fail this rule while still satisfying [Success Criterion 1.3.1 Info and Relationship][sc131].
-- This rule assumes that the intended role of the element is not its [implicit role][]. If no token is valid, User Agents will default to the [implicit role][] for the element; if that role is the intended one, it is possible to fail this rule but still satisfy [Success Criterion 1.3.1 Info and Relationship][sc131].
+- This rule assumes that the intended role of the element is not its [implicit role][]. If no token is valid, User Agents will default to the [implicit role][] for the element; if that role is the intended one, it is possible to fail this rule but still satisfy [Success Criterion 1.3.1 Info and Relationships][sc131].
 
 ## Accessibility Support
 

--- a/_rules/role-required-states-and-properties-4e8ab6.md
+++ b/_rules/role-required-states-and-properties-4e8ab6.md
@@ -5,11 +5,6 @@ rule_type: atomic
 description: |
   This rule checks that elements that have an explicit role also specify all required states and properties.
 accessibility_requirements:
-  wcag20:4.1.2: # Name, Role, Value (A)
-    forConformance: true
-    failed: not satisfied
-    passed: further testing needed
-    inapplicable: further testing needed
   wcag-technique:ARIA5: # Using WAI-ARIA state and property attributes to expose the state of a user interface component
     forConformance: false
     failed: not satisfied
@@ -20,6 +15,10 @@ accessibility_requirements:
     failed: not satisfied
     passed: satisfied
     inapplicable: satisfied
+  wcag20:1.3.1: # Info and Relationships (A)
+    secondary: true
+  wcag20:4.1.2: # Name, Role, Value (A)
+    secondary: true
 input_aspects:
   - DOM Tree
 acknowledgments:
@@ -50,6 +49,8 @@ This rule relies on browsers and assistive technologies to support leaving out [
 **Note:** The required states and properties with implicit values can be found in the Core Accessibility API Mappings 1.1 [Overview of default values for missing required attributes](https://www.w3.org/TR/core-aam-1.1/#authorErrorDefaultValuesTable).
 
 ## Background
+
+Omitting required ARIA properties is often the result of a developer error. When required properties are missing some browsers and assistive technologies will guess the property, or leave the element inaccessible. This can cause issues under [success criterion 1.3.1 Info and Relationships][sc131] or [4.1.2 Name, Rule Value][sc412].
 
 This rule is testing author built components, not user-agent built ones. Elements that keep their [implicit semantic role][] are mapped into conforming accessible objects, with all required properties, by user agents and are therefore not tested by this rule. Most of these mappings are defined in the [HTML Accessibility API Mappings, Attribute State and Property Mappings](https://www.w3.org/TR/html-aam-1.0/#html-attribute-state-and-property-mappings).
 
@@ -227,3 +228,5 @@ This `combobox` is not [included in the accessibility tree][] due to its styling
 [wai-aria 1.2]: https://www.w3.org/TR/wai-aria-1.2/
 [html or svg element]: #namespaced-element
 [focusable]: #focusable
+[sc131]: https://www.w3.org/TR/WCAG21/#info-and-relationships
+[sc412]: https://www.w3.org/TR/WCAG21/#name-role-value

--- a/_rules/text-contrast-enhanced-09o5cg.md
+++ b/_rules/text-contrast-enhanced-09o5cg.md
@@ -5,7 +5,7 @@ rule_type: atomic
 description: |
   This rule checks that the highest possible contrast of every text character with its background meets the enhanced contrast requirement.
 accessibility_requirements:
-  wcag20:1.4.6: # Contrast (Enhanced)
+  wcag20:1.4.6: # Contrast (Enhanced) (AAA)
     forConformance: true
     failed: not satisfied
     passed: further testing needed
@@ -20,6 +20,8 @@ accessibility_requirements:
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
+  wcag20:1.4.3: # Contrast (Minimum) (A)
+    secondary: true
 input_aspects:
   - Accessibility Tree
   - DOM Tree
@@ -65,6 +67,8 @@ Passing this rule does not mean that the text has sufficient color contrast. If 
 
 When the text color or background color is not specified in the web page, colors from other [origins][] will be used. Testers must ensure colors are not affected by styles from a [user origin][], such as a custom style sheet. Contrast issues caused by specifying the text color but not the background or vice versa, must be tested separately from this rule.
 
+This rule is closely related to [success criterion 1.4.3 Contrast (Minimum)][sc143]. Because this rule is stricter, text that passes this rule will likely satisfy 1.4.3 Contrast (Minimum).
+
 ### Bibliography
 
 - [Understanding Success Criterion 1.4.6: Contrast (Enhanced)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-enhanced.html)
@@ -103,13 +107,13 @@ This white text has a contrast ratio between 18:1 and 7:1 on the background imag
 
 ```html
 <style>
-p {
-	color: #FFF;
-	height: 50px;
-	padding-top: 15px;
-	background: #000 no-repeat -20px -20px url('/test-assets/contrast/black-hole.jpeg');
-	text-shadow: 0px 0px 2px black;
-}
+	p {
+		color: #fff;
+		height: 50px;
+		padding-top: 15px;
+		background: #000 no-repeat -20px -20px url('/test-assets/contrast/black-hole.jpeg');
+		text-shadow: 0px 0px 2px black;
+	}
 </style>
 <p>Black hole sun</p>
 ```
@@ -177,7 +181,7 @@ light gray background with a contrast ratio of 18.26:1
 #### Passed Example 10
 
 This text is part of a widget because it is a child of an element with the `role` attribute set to `button`.
-The text has the default browser text color on the default browser background color. By default, this is 
+The text has the default browser text color on the default browser background color. By default, this is
 black text on a white background with a contrast ratio of 21:1
 
 ```html
@@ -459,3 +463,4 @@ This text is part of a [disabled][] widget because it is a child of an element w
 [user origin]: https://www.w3.org/TR/css3-cascade/#cascade-origin-user 'CSS 3, user origin'
 [visible]: #visible 'Definition of Visible'
 [html element]: #namespaced-element
+[sc143]: https://www.w3.org/TR/WCAG21/#contrast-minimum

--- a/package-lock.json
+++ b/package-lock.json
@@ -1869,7 +1869,7 @@
 		},
 		"node_modules/act-tools": {
 			"version": "1.0.0",
-			"resolved": "git+ssh://git@github.com/act-rules/act-tools.git#77377972c5bc295215cf0e5a0e0b222d151826a5",
+			"resolved": "git+ssh://git@github.com/act-rules/act-tools.git#dd7390681cabad72fe63df876181468867961557",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",


### PR DESCRIPTION
- Add secondary requirements to ARIA rules
- Add level A criteria as secondary for level AAA rules
- List 1.1.1 as secondary for link name, because of `area` elements.
- Update act-tools so that secondary requirements are no longer included in the "Rule mapping" section at the page top
- Update the test to allow omitting the mapping on secondary requirements

Need for Call for Review: 1 week

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
