### PR TITLE
Link rules to WAI site rather than CG site

### DIFF
--- a/_rules/aria-hidden-no-focusable-content-6cfa84.md
+++ b/_rules/aria-hidden-no-focusable-content-6cfa84.md
@@ -54,7 +54,7 @@ The 1 second time span introduced in the exception of the definition of [focusab
 
 ### Related rules
 
-- [Element with presentational children has no focusable content](https://act-rules.github.io/rules/307n5z)
+- [Element with presentational children has no focusable content](https://www.w3.org/WAI/standards-guidelines/act/rules/307n5z/proposed/)
 
 ### Bibliography
 

--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -62,7 +62,7 @@ Assessing the value of the attribute is out of scope for this rule.
 
 ### Related rules
 
-- [ARIA state or property has valid value](https://act-rules.github.io/rules/6a7281)
+- [ARIA state or property has valid value](https://www.w3.org/WAI/standards-guidelines/act/rules/6a7281/proposed/)
 
 ### Bibliography
 

--- a/_rules/aria-state-or-property-valid-value-6a7281.md
+++ b/_rules/aria-state-or-property-valid-value-6a7281.md
@@ -50,7 +50,7 @@ For value type `URI`, this rule does not require that the destination URI exists
 
 ### Related rules
 
-- [ARIA state or property is permitted](https://act-rules.github.io/rules/5c01ea)
+- [ARIA state or property is permitted](https://www.w3.org/WAI/standards-guidelines/act/rules/5c01ea/proposed/)
 
 ### Bibliography
 

--- a/_rules/audio-or-video-avoids-automatically-playing-audio-80f0bf.md
+++ b/_rules/audio-or-video-avoids-automatically-playing-audio-80f0bf.md
@@ -62,8 +62,8 @@ This rule applies to any `audio` or `video` element for which all the following 
 
 For each test target, the [outcome](#outcome) of at least one of the following rules is passed:
 
-- [Audio Or Video That Plays Automatically Has A Control Mechanism](https://act-rules.github.io/rules/4c31df)
-- [Audio Or Video That Plays Automatically Has No Audio That Lasts More Than 3 Seconds](https://act-rules.github.io/rules/aaa1bf)
+- [Audio Or Video That Plays Automatically Has A Control Mechanism](https://www.w3.org/WAI/standards-guidelines/act/rules/4c31df/proposed/)
+- [Audio Or Video That Plays Automatically Has No Audio That Lasts More Than 3 Seconds](https://www.w3.org/WAI/standards-guidelines/act/rules/aaa1bf/proposed/)
 
 ## Assumptions
 

--- a/_rules/audio-text-alternative-e7aa44.md
+++ b/_rules/audio-text-alternative-e7aa44.md
@@ -41,8 +41,8 @@ This rule applies to any [non-streaming](#non-streaming-media-element) `audio` e
 
 For each test target, the [outcome](#outcome) of at least one of the following rules is passed:
 
-- [`Audio` Element Content Has Transcript](https://act-rules.github.io/rules/2eb176)
-- [`Audio` Element Content Is Media Alternative For Text](https://act-rules.github.io/rules/afb423)
+- [`Audio` Element Content Has Transcript](https://www.w3.org/WAI/standards-guidelines/act/rules/2eb176/proposed/)
+- [`Audio` Element Content Is Media Alternative For Text](https://www.w3.org/WAI/standards-guidelines/act/rules/afb423/proposed/)
 
 ## Assumptions
 

--- a/_rules/button-non-empty-accessible-name-97a4e1.md
+++ b/_rules/button-non-empty-accessible-name-97a4e1.md
@@ -46,7 +46,7 @@ This rule considers an exception for "image buttons" (i.e., `input` elements wit
 
 ### Related rules
 
-- [Image button has non-empty accessible name](https://act-rules.github.io/rules/59796f)
+- [Image button has non-empty accessible name](https://www.w3.org/WAI/standards-guidelines/act/rules/59796f/)
 
 ### Bibliography
 

--- a/_rules/bypass-blocks-cf77f2.md
+++ b/_rules/bypass-blocks-cf77f2.md
@@ -506,12 +506,12 @@ This [document][] is not an [HTML web page][].
 ```
 
 [block of content]: #block-of-content 'Definition of Block of Content'
-[block collapsible]: https://act-rules.github.io/rules/3e12e1 'Rule Block of Repeated Content is Collapsible'
+[block collapsible]: https://www.w3.org/WAI/standards-guidelines/act/rules/3e12e1/proposed/ 'Rule Block of Repeated Content is Collapsible'
 [block of repeated content]: #block-of-repeated-content 'Definition of Block of Repeated Content'
 [document]: https://dom.spec.whatwg.org/#concept-document 'DOM definition of Document'
-[document has landmark]: https://act-rules.github.io/rules/b40fd1 'Rule Document Has a Landmark with Non-Repeated Content'
-[document has instrument to main]: https://act-rules.github.io/rules/ye5d6e 'Rule Document Has an Instrument to Move Focus to Non-Repeated Content'
-[document has heading for main]: https://act-rules.github.io/rules/047fe0 'Rule Document Has Heading for Non-Repeated Content'
+[document has landmark]: https://www.w3.org/WAI/standards-guidelines/act/rules/b40fd1/proposed/ 'Rule Document Has a Landmark with Non-Repeated Content'
+[document has instrument to main]: https://www.w3.org/WAI/standards-guidelines/act/rules/ye5d6e/proposed/ 'Rule Document Has an Instrument to Move Focus to Non-Repeated Content'
+[document has heading for main]: https://www.w3.org/WAI/standards-guidelines/act/rules/047fe0/proposed/ 'Rule Document Has Heading for Non-Repeated Content'
 [focusable]: #focusable 'Definition of Focusable'
 [html web page]: #web-page-html 'Definition of Web Page (HTML)'
 [included in the accessibility tree]: #included-in-the-accessibility-tree 'Definition of Included in the Accessibility Tree'

--- a/_rules/element-lang-matches-default-language-off6ek.md
+++ b/_rules/element-lang-matches-default-language-off6ek.md
@@ -62,7 +62,7 @@ This rule checks that, if a `lang` attribute is used, its value is correct with 
 
 ### Related rules
 
-- [_Element with `lang` Attribute Has Valid Language Tag_](https://act-rules.github.io/rules/de46e4)
+- [_Element with `lang` Attribute Has Valid Language Tag_](https://www.w3.org/WAI/standards-guidelines/act/rules/de46e4/)
 
 ### Bibliography
 

--- a/_rules/focusable-no-keyboard-trap-80af7b.md
+++ b/_rules/focusable-no-keyboard-trap-80af7b.md
@@ -41,8 +41,8 @@ This rule applies to any [HTML or SVG element][] that is [focusable][].
 
 For each test target, the [outcome](#outcome) of at least one of the following rules is "passed":
 
-- [Focusable Element Has No Keyboard Trap Via Standard Navigation](https://act-rules.github.io/rules/a1b64e)
-- [Focusable Element Has No Keyboard Trap Via Non-Standard Navigation](https://act-rules.github.io/rules/ebe86a)
+- [Focusable Element Has No Keyboard Trap Via Standard Navigation](https://www.w3.org/WAI/standards-guidelines/act/rules/a1b64e/proposed/)
+- [Focusable Element Has No Keyboard Trap Via Non-Standard Navigation](https://www.w3.org/WAI/standards-guidelines/act/rules/ebe86a/proposed/)
 
 ## Assumptions
 

--- a/_rules/html-page-lang-b5c3f8.md
+++ b/_rules/html-page-lang-b5c3f8.md
@@ -51,8 +51,8 @@ There are no accessibility support issues known.
 
 ### Related rules
 
-- [HTML page `lang` attribute has valid language tag](https://act-rules.github.io/rules/bf051a)
-- [HTML page language subtag matches default language](https://act-rules.github.io/rules/ucwvc8)
+- [HTML page `lang` attribute has valid language tag](https://www.w3.org/WAI/standards-guidelines/act/rules/bf051a/)
+- [HTML page language subtag matches default language](https://www.w3.org/WAI/standards-guidelines/act/rules/ucwvc8/proposed/)
 
 ### Bibliography
 

--- a/_rules/html-page-lang-matches-default-ucwvc8.md
+++ b/_rules/html-page-lang-matches-default-ucwvc8.md
@@ -64,8 +64,8 @@ There are no accessibility support issues known.
 
 ### Related rules
 
-- [HTML page has `lang` attribute](https://act-rules.github.io/rules/b5c3f8)
-- [HTML page `lang` attribute has valid language tag](https://act-rules.github.io/rules/bf051a)
+- [HTML page has `lang` attribute](https://www.w3.org/WAI/standards-guidelines/act/rules/b5c3f8/)
+- [HTML page `lang` attribute has valid language tag](https://www.w3.org/WAI/standards-guidelines/act/rules/bf051a/proposed/)
 
 ### Bibliography
 

--- a/_rules/html-page-lang-valid-bf051a.md
+++ b/_rules/html-page-lang-valid-bf051a.md
@@ -56,8 +56,8 @@ This rule is only applicable to non-embedded HTML pages. HTML pages embedded int
 
 ### Related rules
 
-- [HTML page has `lang` attribute](https://act-rules.github.io/rules/b5c3f8)
-- [HTML page language subtag matches default language](https://act-rules.github.io/rules/ucwvc8)
+- [HTML page has `lang` attribute](https://www.w3.org/WAI/standards-guidelines/act/rules/b5c3f8/)
+- [HTML page language subtag matches default language](https://www.w3.org/WAI/standards-guidelines/act/rules/ucwvc8/proposed/)
 
 ### Bibliography
 

--- a/_rules/html-page-non-empty-title-2779a5.md
+++ b/_rules/html-page-non-empty-title-2779a5.md
@@ -63,7 +63,7 @@ This rule is only applicable to non-embedded HTML pages. HTML pages embedded int
 
 ### Related rules
 
-- [HTML page title is descriptive](https://act-rules.github.io/rules/c4a8a4)
+- [HTML page title is descriptive](https://www.w3.org/WAI/standards-guidelines/act/rules/c4a8a4/proposed/)
 
 ### Bibliography
 

--- a/_rules/html-page-title-descriptive-c4a8a4.md
+++ b/_rules/html-page-title-descriptive-c4a8a4.md
@@ -59,7 +59,7 @@ The [HTML specification - The `title` element](https://html.spec.whatwg.org/#the
 
 ### Related rules
 
-- [HTML page has non-empty title](https://www.w3.org/WAI/standards-guidelines/act/rules/2779a5)
+- [HTML page has non-empty title](https://www.w3.org/WAI/standards-guidelines/act/rules/2779a5/)
 
 ### Bibliography
 

--- a/_rules/html-page-title-descriptive-c4a8a4.md
+++ b/_rules/html-page-title-descriptive-c4a8a4.md
@@ -59,7 +59,7 @@ The [HTML specification - The `title` element](https://html.spec.whatwg.org/#the
 
 ### Related rules
 
-- [HTML page has non-empty title](https://act-rules.github.io/rules/2779a5)
+- [HTML page has non-empty title](https://www.w3.org/WAI/standards-guidelines/act/rules/2779a5)
 
 ### Bibliography
 

--- a/_rules/image-button-non-empty-accessible-name-59796f.md
+++ b/_rules/image-button-non-empty-accessible-name-59796f.md
@@ -64,7 +64,7 @@ Contrarily to `img` elements, an empty `alt` attribute does not make image butto
 
 ### Related rules
 
-- [Button has non-empty accessible name](https://act-rules.github.io/rules/97a4e1)
+- [Button has non-empty accessible name](https://www.w3.org/WAI/standards-guidelines/act/rules/97a4e1/)
 
 ### Bibliography
 

--- a/_rules/image-filename-as-accessible-name-9eb3f6.md
+++ b/_rules/image-filename-as-accessible-name-9eb3f6.md
@@ -40,7 +40,7 @@ assets:
   - The picture of Nyhavn (Copenhagen) is authored by [Jorge Franganillo](https://500px.com/franganillo), licensed under the [Creative Commons Attribution 3.0 Unported](https://creativecommons.org/licenses/by/3.0/deed.en) license.
   - The picture of bread is a public domain [picture by Bicanski](https://pixnio.com/media/bread-breakfast-fresh-homemade-wheat).
 deprecated: |
-  This rule has been deprecated and superseded by Rule [Image accessible name is descriptive](https://www.w3.org/WAI/standards-guidelines/act/rules/qt1vmo). This rule is not maintained anymore and should not be used.
+  This rule has been deprecated and superseded by Rule [Image accessible name is descriptive](https://www.w3.org/WAI/standards-guidelines/act/rules/qt1vmo/proposed/). This rule is not maintained anymore and should not be used.
 ---
 
 ## Applicability

--- a/_rules/image-filename-as-accessible-name-9eb3f6.md
+++ b/_rules/image-filename-as-accessible-name-9eb3f6.md
@@ -40,7 +40,7 @@ assets:
   - The picture of Nyhavn (Copenhagen) is authored by [Jorge Franganillo](https://500px.com/franganillo), licensed under the [Creative Commons Attribution 3.0 Unported](https://creativecommons.org/licenses/by/3.0/deed.en) license.
   - The picture of bread is a public domain [picture by Bicanski](https://pixnio.com/media/bread-breakfast-fresh-homemade-wheat).
 deprecated: |
-  This rule has been deprecated and superseded by Rule [Image accessible name is descriptive](https://act-rules.github.io/rules/qt1vmo). This rule is not maintained anymore and should not be used.
+  This rule has been deprecated and superseded by Rule [Image accessible name is descriptive](https://www.w3.org/WAI/standards-guidelines/act/rules/qt1vmo). This rule is not maintained anymore and should not be used.
 ---
 
 ## Applicability

--- a/_rules/link-alone-descriptive-aizyf1.md
+++ b/_rules/link-alone-descriptive-aizyf1.md
@@ -46,7 +46,7 @@ Each test target has an [accessible name][] which describes its purpose.
 
 ### Related rules
 
-- [Link has non-empty accessible name](https://act-rules.github.io/rules/c487ae)
+- [Link has non-empty accessible name](https://www.w3.org/WAI/standards-guidelines/act/rules/c487ae/)
 
 ### Bibliography
 

--- a/_rules/link-in-context-descriptive-5effbb.md
+++ b/_rules/link-in-context-descriptive-5effbb.md
@@ -57,8 +57,8 @@ This rule is designed specifically for [2.4.4 Link Purpose (In Context)][sc244],
 
 ### Related rules
 
-- [Link has non-empty accessible name](https://act-rules.github.io/rules/c487ae)
-- [Link is descriptive](https://act-rules.github.io/rules/aizyf1)
+- [Link has non-empty accessible name](https://www.w3.org/WAI/standards-guidelines/act/rules/c487ae/)
+- [Link is descriptive](https://www.w3.org/WAI/standards-guidelines/act/rules/aizyf1/proposed/)
 
 ### Bibliography
 
@@ -213,8 +213,16 @@ The [programmatically determined link context][] (provided by the element refere
 ```html
 <h2 id="rule">Button has accessible name</h2>
 <ul>
-	<li><a href="https://act-rules.github.io/rules/97a4e1#applicability" aria-describedby="rule">Applicability</a></li>
-	<li><a href="https://act-rules.github.io/rules/97a4e1#expectation" aria-describedby="rule">Expectation</a></li>
+	<li>
+		<a href="https://www.w3.org/WAI/standards-guidelines/act/rules/97a4e1/#applicability" aria-describedby="rule"
+			>Applicability</a
+		>
+	</li>
+	<li>
+		<a href="https://www.w3.org/WAI/standards-guidelines/act/rules/97a4e1/#expectation" aria-describedby="rule"
+			>Expectation</a
+		>
+	</li>
 </ul>
 ```
 

--- a/_rules/link-non-empty-accessible-name-c487ae.md
+++ b/_rules/link-non-empty-accessible-name-c487ae.md
@@ -66,7 +66,7 @@ The rule assumes that all links are [user interface components](https://www.w3.o
 
 ### Related rules
 
-- [Link in context is descriptive](https://act-rules.github.io/rules/5effbb)
+- [Link in context is descriptive](https://www.w3.org/WAI/standards-guidelines/act/rules/5effbb/proposed/)
 
 ### Bibliography
 

--- a/_rules/presentational-children-no-focusable-content-307n5z.md
+++ b/_rules/presentational-children-no-focusable-content-307n5z.md
@@ -44,7 +44,7 @@ Elements with a [semantic role][] that has [presentational children][] will not 
 
 ### Related rules
 
-- [Element with aria-hidden has no focusable content](https://act-rules.github.io/rules/6cfa84)
+- [Element with aria-hidden has no focusable content](https://www.w3.org/WAI/standards-guidelines/act/rules/6cfa84/)
 
 ### Bibliography
 

--- a/_rules/scrollable-element-keyboard-accessible-0ssw9k.md
+++ b/_rules/scrollable-element-keyboard-accessible-0ssw9k.md
@@ -56,7 +56,7 @@ Some browsers restrict scrolling to the [content box](https://drafts.csswg.org/c
 
 To ensure there is some element from which arrow keys can be used to control the scroll position, focus must be on or in a scrollable region. If scripts are used to prevent the keyboard events from reaching the scrollable region, this could still cause a keyboard accessibility issue. This must be tested separately.
 
-This rule only applies to elements who scroll content in the same document. Elements such as iframes that embed other documents may also be scrollable, but for them it is the embedded document that scrolls, not the content in the same document. Such scenarios are tested separately with rules such as [Iframe with negative tabindex has no interactive elements](https://act-rules.github.io/rules/akn7bn).
+This rule only applies to elements who scroll content in the same document. Elements such as iframes that embed other documents may also be scrollable, but for them it is the embedded document that scrolls, not the content in the same document. Such scenarios are tested separately with rules such as [Iframe with negative tabindex has no interactive elements](https://www.w3.org/WAI/standards-guidelines/act/rules/akn7bn/proposed/).
 
 ### Bibliography
 

--- a/_rules/video-alternative-for-auditory-eac66b.md
+++ b/_rules/video-alternative-for-auditory-eac66b.md
@@ -46,8 +46,8 @@ This rule applies to every [non-streaming](#non-streaming-media-element) `video`
 
 For each test target, the [outcome](#outcome) of at least one of the following rules is passed:
 
-- [`Video` Element Content Is Media Alternative For Text](https://act-rules.github.io/rules/ab4d13)
-- [`Video` Element Auditory Content Has Captions](https://act-rules.github.io/rules/f51b46)
+- [`Video` Element Content Is Media Alternative For Text](https://www.w3.org/WAI/standards-guidelines/act/rules/ab4d13/proposed/)
+- [`Video` Element Auditory Content Has Captions](https://www.w3.org/WAI/standards-guidelines/act/rules/f51b46/proposed/)
 
 ## Assumptions
 

--- a/_rules/video-alternative-for-visual-c5a4ea.md
+++ b/_rules/video-alternative-for-visual-c5a4ea.md
@@ -67,9 +67,9 @@ This rule applies to every [non-streaming](#non-streaming-media-element) `video`
 
 For each test target, the [outcome](#outcome) of at least one of the following rules is passed:
 
-- [`Video` Element Visual Content Has Audio Description](https://act-rules.github.io/rules/1ea59c)
-- [`Video` Element Visual Content Has Transcript](https://act-rules.github.io/rules/1a02b0)
-- [`Video` Element Content Is Media Alternative For Text](https://act-rules.github.io/rules/ab4d13)
+- [`Video` Element Visual Content Has Audio Description](https://www.w3.org/WAI/standards-guidelines/act/rules/1ea59c/proposed/)
+- [`Video` Element Visual Content Has Transcript](https://www.w3.org/WAI/standards-guidelines/act/rules/1a02b0/proposed/)
+- [`Video` Element Content Is Media Alternative For Text](https://www.w3.org/WAI/standards-guidelines/act/rules/ab4d13/proposed/)
 
 ## Assumptions
 

--- a/_rules/video-only-alternative-for-visual-c3232f.md
+++ b/_rules/video-only-alternative-for-visual-c3232f.md
@@ -49,9 +49,9 @@ This rule applies to any [non-streaming](#non-streaming-media-element) `video` e
 
 For each test target, the [outcome](#outcome) of at least one of the following rules is passed:
 
-- [`Video` Element Visual-Only Content Is Media Alternative For Text](https://act-rules.github.io/rules/fd26cf)
-- [`Video` Element Visual-Only Content Has Transcript](https://act-rules.github.io/rules/ee13b5)
-- [`Video` Element Visual-Only Content Has Audio Track Alternative](https://act-rules.github.io/rules/d7ba54)
+- [`Video` Element Visual-Only Content Is Media Alternative For Text](https://www.w3.org/WAI/standards-guidelines/act/rules/fd26cf/proposed/)
+- [`Video` Element Visual-Only Content Has Transcript](https://www.w3.org/WAI/standards-guidelines/act/rules/ee13b5/proposed/)
+- [`Video` Element Visual-Only Content Has Audio Track Alternative](https://www.w3.org/WAI/standards-guidelines/act/rules/d7ba54/proposed/)
 
 ## Assumptions
 
@@ -76,7 +76,7 @@ The HTML `video` element can also have a `track` element that provides an audio 
 
 #### Passed Example 1
 
-This `video` element, which has no audio, has a text transcript available on the same page. Thus, it passes rule [`Video` Element Visual-Only Content Has Transcript](https://act-rules.github.io/rules/ee13b5).
+This `video` element, which has no audio, has a text transcript available on the same page. Thus, it passes rule [`Video` Element Visual-Only Content Has Transcript](https://www.w3.org/WAI/standards-guidelines/act/rules/ee13b5/proposed/).
 
 ```html
 <html lang="en">
@@ -92,7 +92,7 @@ Then he stops to scratch his bottom.</p>
 
 #### Passed Example 2
 
-This `video` element, which has no audio, has a separate audio track that describes the visual information. Thus, it passes rule [`Video` Element Visual-Only Content Has Audio Track Alternative](https://act-rules.github.io/rules/d7ba54).
+This `video` element, which has no audio, has a separate audio track that describes the visual information. Thus, it passes rule [`Video` Element Visual-Only Content Has Audio Track Alternative](https://www.w3.org/WAI/standards-guidelines/act/rules/d7ba54/proposed/).
 
 ```html
 <html lang="en">
@@ -109,7 +109,7 @@ This `video` element, which has no audio, has a separate audio track that descri
 
 #### Passed Example 3
 
-This `video` element, which has no audio, is a media alternative for the text in the page and labeled as such. Thus, it passes rule [`Video` Element Visual-Only Content Is Media Alternative For Text](https://act-rules.github.io/rules/fd26cf).
+This `video` element, which has no audio, is a media alternative for the text in the page and labeled as such. Thus, it passes rule [`Video` Element Visual-Only Content Is Media Alternative For Text](https://www.w3.org/WAI/standards-guidelines/act/rules/fd26cf/proposed/).
 
 ```html
 <html lang="en">

--- a/_rules/video-strict-alternative-for-visual-1ec09b.md
+++ b/_rules/video-strict-alternative-for-visual-1ec09b.md
@@ -47,8 +47,8 @@ This rule applies to every [non-streaming](#non-streaming-media-element) `video`
 
 For each test target, the [outcome](#outcome) of at least one of the following rules is passed:
 
-- [`Video` Element Visual Content Has Audio Description](https://act-rules.github.io/rules/1ea59c)
-- [`Video` Element Content Is Media Alternative For Text](https://act-rules.github.io/rules/ab4d13)
+- [`Video` Element Visual Content Has Audio Description](https://www.w3.org/WAI/standards-guidelines/act/rules/1ea59c/proposed/)
+- [`Video` Element Content Is Media Alternative For Text](https://www.w3.org/WAI/standards-guidelines/act/rules/ab4d13/proposed/)
 
 ## Assumptions
 


### PR DESCRIPTION
Fix hard-coded links so they go to the WAI website rather than the CG website.

Need for Call for Review: none, changes are editorial.

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
