### PR TITLE
"semantic role" -> "semantic roles" where appropriate

### DIFF
--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -109,7 +109,7 @@ The `aria-busy` [state][] is a [global][] [state][] that is [supported][] by all
 
 #### Passed Example 4
 
-The `aria-label` [property][] is a [global][] [property][] and thus [inherited][] for all [semantic role][].
+The `aria-label` [property][] is a [global][] [property][] and thus [inherited][] for all [semantic roles][].
 
 ```html
 <div role="button" aria-label="OK">✓</div>
@@ -149,7 +149,7 @@ The `aria-controls` [property][] is [required][] for the [semantic][semantic rol
 
 #### Passed Example 9
 
-The `aria-label` [property][] is [global][] and thus [inherited][] for all [semantic role][], including the ones from the [WAI-ARIA Graphics Module](https://www.w3.org/TR/graphics-aria-1.0). This rule is also applicable to SVG elements.
+The `aria-label` [property][] is [global][] and thus [inherited][] for all [semantic roles][], including the ones from the [WAI-ARIA Graphics Module](https://www.w3.org/TR/graphics-aria-1.0). This rule is also applicable to SVG elements.
 
 ```html
 <svg xmlns="http://www.w3.org/2000/svg" role="graphics-object" width="100" height="100" aria-label="yellow circle">
@@ -228,6 +228,7 @@ This `div` element is not [included in the accessibility tree][], hence its [WAI
 [property]: https://www.w3.org/TR/wai-aria-1.2/#dfn-property 'Definition of ARIA Property'
 [required]: https://www.w3.org/TR/wai-aria-1.2/#requiredState 'Definition of Required ARIA States and Properties'
 [semantic role]: #semantic-role 'Definition of Semantic Role'
+[semantic roles]: #semantic-role 'Definition of Semantic Role'
 [state]: https://www.w3.org/TR/wai-aria-1.2/#dfn-state 'Definition of ARIA State'
 [supported]: https://www.w3.org/TR/wai-aria-1.2/#supportedState 'Definition of Supported ARIA States and Properties'
 [wai-aria state or property]: https://www.w3.org/TR/wai-aria-1.2/#state_prop_def 'Definition of ARIA States and Properties'


### PR DESCRIPTION
<< Describe the changes >>

Closes issue(s):

- closes #XXX (ADD ISSUE NUMBER HERE)

Need for Call for Review:
<< choose one of the following and remove the rest >>
<< check [Process Document on Call for Review](https://act-rules.github.io/pages/design/process/#call-for-review) >>
This can be merged with 1 approval << choose reason: editorial changes to website/test code, adding new contributor, other (explain). >>

---

## Pull Request Etiquette

### **When creating PR:**

- [x] Make sure you're requesting to **pull a branch** (right side) to the `develop` branch (left side).
- [x] Make sure you do not remove the "How to Review and Approve" section in your pull request description

### **After creating PR:**

- [x] Add yourself (and co-authors) as "Assignees" for PR.
- [x] Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- [ ] [Link the PR to any issue it solves](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue). This will be done automatically by [referencing the issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) at the top of this comment in the indicated place.
- [x] Optionally request feedback from anyone in particular by assigning them as "Reviewers".

### **When merging a PR:**

- [ ] Close any issue that the PR resolves. This will happen automatically upon merging if the PR was correctly linked to the issue, e.g. by referencing the issue at the top of this comment.

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
