### PR TITLE
"Focusable element has no keyboard trap" [80af7b]: fix Failed example and add clarification

### DIFF
--- a/_rules/focusable-no-keyboard-trap-80af7b.md
+++ b/_rules/focusable-no-keyboard-trap-80af7b.md
@@ -54,6 +54,8 @@ There are no accessibility support issues known.
 
 ## Background
 
+This rule only requires navigation in one direction (either forward or backward), not both, and not a specific one. It is clear that not being able to escape a focus trap in any direction is a failure of [Success Criterion 2.1.2 No keyboard trap][sc212]. However, it is less clear that being able to escape in only one direction is enough to satisfy it. If [Success Criterion 2.1.2 No keyboard trap][sc212] requires the possibility to escape the trap in a specific way (e.g. forward [standard keyboard navigation](#standard-keyboard-navigation)) or in both directions, this rule may pass while the criterion is not satisfied.
+
 ### Bibliography
 
 - [Understanding Success Criterion 2.1.2: No Keyboard Trap](https://www.w3.org/WAI/WCAG21/Understanding/no-keyboard-trap.html)
@@ -149,13 +151,14 @@ These focusable `button` elements have scripts that create a keyboard trap. The 
 
 #### Failed Example 1
 
-This [focusable][] element creates a keyboard trap bringing focus to the `button`.
+This [focusable][] element creates a keyboard trap bringing focus to the `button`. Note that if one of the links is removed, the focus may jump to the browser UI before the timeout expires, at which point the `this.focus()` trap cannot trigger anymore.
 
 ```html
 <a href="#">Link 1</a>
 <button onblur="setTimeout(() => this.focus(), 10)">
 	Button1
 </button>
+<a href="#">Link 2</a>
 ```
 
 #### Failed Example 2

--- a/_rules/focusable-no-keyboard-trap-80af7b.md
+++ b/_rules/focusable-no-keyboard-trap-80af7b.md
@@ -276,3 +276,5 @@ There is no [focusable][] element.
 
 [focusable]: #focusable 'Definition of focusable'
 [html or svg element]: #namespaced-element
+[sc212]: https://www.w3.org/TR/WCAG21/#no-keyboard-trap 'Success Criterion 2.1.2 No Keyboard Trap'
+


### PR DESCRIPTION
Updates were made to an atomic rule in #1905 for "Focusable element has no keyboard trap via standard navigation" [a1b64e]

- Fix Failed Example 1 to ensure there actually is a keyboard trap
- Add a clarification about forward and backward navigation

Making the same updates for the composite rule.