### PR TITLE
Autocomplete: include webauthn token example

### DIFF
--- a/__tests__/spelling-ignore.yml
+++ b/__tests__/spelling-ignore.yml
@@ -85,6 +85,7 @@
 - iso # lowercase needed in reference list
 - RFC
 - rfc
+- webauthn
 
 # spell checker checks against strict casing & hence some repeated words here
 - Autocomplete

--- a/_rules/autocomplete-valid-value-73f2c2.md
+++ b/_rules/autocomplete-valid-value-73f2c2.md
@@ -149,7 +149,7 @@ This `autocomplete` [attribute value][] only has the required token "bday-day". 
 <label>Birthday day<input name="bdayday" type="tel" autocomplete="bday-day"/></label>
 ```
 
-#### Passed Example 8
+#### Passed Example 9
 
 This `autocomplete` [attribute value][] only has the required token "current-password", followed by the optional "webauthn" token.
 

--- a/_rules/autocomplete-valid-value-73f2c2.md
+++ b/_rules/autocomplete-valid-value-73f2c2.md
@@ -39,7 +39,8 @@ Each test target's `autocomplete` [attribute value][] is a [space separated][] l
 1. An optional token that starts with "section-"; then
 2. An optional token of either "shipping" or "billing"; then
 3. An optional token of either "home", "work", "mobile", "fax" or "pager", only if the last token is "email", "impp", "tel" or "tel-\*"; then
-4. A required token from the [correct autocomplete field][].
+4. A required token from the [correct autocomplete field][]; then
+5. An optional "webauthn" token.
 
 ## Assumptions
 
@@ -146,6 +147,17 @@ This `autocomplete` [attribute value][] only has the required token "bday-day". 
 
 ```html
 <label>Birthday day<input name="bdayday" type="tel" autocomplete="bday-day"/></label>
+```
+
+#### Passed Example 8
+
+This `autocomplete` [attribute value][] only has the required token "current-password", followed by the optional "webauthn" token.
+
+```html
+<label>
+	Password
+	<input type="password" autocomplete="current-password webauthn" />
+</label>
 ```
 
 ### Failed

--- a/_rules/autocomplete-valid-value-73f2c2.md
+++ b/_rules/autocomplete-valid-value-73f2c2.md
@@ -151,7 +151,7 @@ This `autocomplete` [attribute value][] only has the required token "bday-day". 
 
 #### Passed Example 9
 
-This `autocomplete` [attribute value][] only has the required token "current-password", followed by the optional "webauthn" token.
+This `autocomplete` [attribute value][] has the required token "current-password", followed by the optional "webauthn" token.
 
 ```html
 <label>


### PR DESCRIPTION
This token was added to HTML 5 a while back: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete-webauthn Since the rule lists out what things are allowed I figured I'd add an explicit example for it.

Need for Call for Review: 1 week

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
