### PR TITLE
Ignore query parameters when checking URL existence

### DIFF
--- a/_rules/__tests__/test-assets.js
+++ b/_rules/__tests__/test-assets.js
@@ -17,7 +17,9 @@ describeRule('check if referenced test assets exists', ruleData => {
 	if (usedAssetPaths.length) {
 		test.each(usedAssetPaths)('%s', assetPath => {
 			const message = `Asset at path -> ${assetPath} does not exist`
-			expect(allTestAssetPaths.includes(assetPath), message).toBe(true)
+			// Crudely filtering out query parameters by removing the first question
+			// mark and everything after it, which is sufficient for our use case.
+			expect(allTestAssetPaths.includes(assetPath.replace(/\?.*/, '')), message).toBe(true)
 		})
 	}
 })


### PR DESCRIPTION
Test are breaking in #2007 due to query parameter in URL and the test not finding a file with the exact same name.
This should ignore the query parameters when searching for existence of files.

There is a small risk that it would also ignore a fragment after a query parameter, but that doesn't seem to be something we are doing now, so this is likely OK.

Closes issue(s):

- N/A

Need for Call for Review:
This will not require a Call for Review (updating test code only).

---

## Pull Request Etiquette

### **When creating PR:**

- [X] Make sure you're requesting to **pull a branch** (right side) to the `develop` branch (left side).
- [X] Make sure you do not remove the "How to Review and Approve" section in your pull request description

### **After creating PR:**

- [X] Add yourself (and co-authors) as "Assignees" for PR.
- [ ] Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- [ ] [Link the PR to any issue it solves](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue). This will be done automatically by [referencing the issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) at the top of this comment in the indicated place.
- [X] Optionally request feedback from anyone in particular by assigning them as "Reviewers".

### **When merging a PR:**

- [ ] Close any issue that the PR resolves. This will happen automatically upon merging if the PR was correctly linked to the issue, e.g. by referencing the issue at the top of this comment.

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
