### PR TITLE
Updating Set of Instruments Definition to have Objective=False

### DIFF
--- a/pages/glossary/set-of-clearly-labeled-instruments.md
+++ b/pages/glossary/set-of-clearly-labeled-instruments.md
@@ -2,7 +2,7 @@
 title: Set of clearly labeled instruments
 key: set-of-clearly-labeled-instruments
 unambiguous: true
-objective: true
+objective: false
 ---
 
 A _set of clearly labeled instruments_ is a set of [instruments][instrument], where each [instrument][] is in the same [web page][] as the test target or can be found in a [clearly labeled location][] from that [web page][].


### PR DESCRIPTION
The definition for set of instruments has objective set to true, but relies on `instrument` and `clearly labelled location` which both have objective set to false, which I think should logically mean this definition isn't objective. 

I do not believe that this definition is used in any place where it would need to be objective (i.e., the applicability) so I think it is fine to change. 

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
