### PR TITLE
Deprecate HTML page lang and xml:lang attributes have matching values

### DIFF
--- a/_rules/html-page-lang-xml-lang-match-5b7ae0.md
+++ b/_rules/html-page-lang-xml-lang-match-5b7ae0.md
@@ -13,7 +13,7 @@ accessibility_requirements:
 input_aspects:
   - DOM Tree # The tree that HTML is parsed into.
 deprecated: |
-  This rule has been deprecated, as modern screen readers no longer use xml:lang when the lang attribute is given, regardless of which MIME type the pages is served with. This rule is not maintained anymore and should not be used.
+  This rule has been deprecated, as modern screen readers no longer use xml:lang when the lang attribute is given, regardless of which MIME type the page is served with. This rule is not maintained anymore and should not be used.
 acknowledgments:
   authors:
     - Jey Nandakumar

--- a/_rules/html-page-lang-xml-lang-match-5b7ae0.md
+++ b/_rules/html-page-lang-xml-lang-match-5b7ae0.md
@@ -1,6 +1,6 @@
 ---
 id: 5b7ae0
-name: HTML page lang and xml:lang attributes have matching values
+name: DEPRECATED — HTML page lang and xml:lang attributes have matching values
 rule_type: atomic
 description: |
   This rule checks that both `lang` and `xml:lang` attributes on the root element of a non-embedded HTML page, have the same primary language subtag.
@@ -12,6 +12,8 @@ accessibility_requirements:
     inapplicable: further testing needed
 input_aspects:
   - DOM Tree # The tree that HTML is parsed into.
+deprecated: |
+  This rule has been deprecated, as modern screen readers no longer use xml:lang when the lang attribute is given, regardless of which MIME type the pages is served with. This rule is not maintained anymore and should not be used.
 acknowledgments:
   authors:
     - Jey Nandakumar


### PR DESCRIPTION
Modern assistive technologies do not use xml:lang when the lang attribute is used, regardless of how a page is served. There is no situation in which a difference between xml:lang and lang can cause an accessibility issue as far as any of us can tell. The lang attribute still has to be correct though.

Closes #1921

Need for Call for Review: 2 weeks, this is a substantial change

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
