### PR TITLE
Remove "DEPRECATED" from rule names

### DIFF
--- a/_rules/html-page-lang-xml-lang-match-5b7ae0.md
+++ b/_rules/html-page-lang-xml-lang-match-5b7ae0.md
@@ -1,6 +1,6 @@
 ---
 id: 5b7ae0
-name: DEPRECATED — HTML page lang and xml:lang attributes have matching values
+name: HTML page lang and xml:lang attributes have matching values
 rule_type: atomic
 description: |
   This rule checks that both `lang` and `xml:lang` attributes on the root element of a non-embedded HTML page, have the same primary language subtag.

--- a/_rules/image-filename-as-accessible-name-9eb3f6.md
+++ b/_rules/image-filename-as-accessible-name-9eb3f6.md
@@ -1,6 +1,6 @@
 ---
 id: 9eb3f6
-name: DEPRECATED — Image filename is accessible name for image
+name: Image filename is accessible name for image
 rule_type: atomic
 description: |
   This rule checks that image elements that use their source filename as their accessible name do so without loss of information to the user.

--- a/_rules/video-description-track-f196ce.md
+++ b/_rules/video-description-track-f196ce.md
@@ -1,6 +1,6 @@
 ---
 id: f196ce
-name: DEPRECATED — Video element visual content has description track
+name: Video element visual content has description track
 rule_type: atomic
 description: |
   This rule checks that description tracks that come with non-streaming `video` elements are descriptive.

--- a/_rules/video-only-description-track-ac7dc6.md
+++ b/_rules/video-only-description-track-ac7dc6.md
@@ -1,6 +1,6 @@
 ---
 id: ac7dc6
-name: DEPRECATED — Video element visual-only content has description track
+name: Video element visual-only content has description track
 rule_type: atomic
 description: |
   This rule checks that description tracks that come with non-streaming `video` elements, without audio, are descriptive.


### PR DESCRIPTION
This "DEPRECATED" in the rule title is no longer necessary as these rules are now sorted in their own section on the ACT site, and the deprecated rule text is added to the rule page.

Need for Call for Review: none, editorial change

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
