### PR TITLE
HTML page has non-empty title [2779a5]: Shadow root example - Included as failed example 6

### DIFF
--- a/_rules/html-page-non-empty-title-2779a5.md
+++ b/_rules/html-page-non-empty-title-2779a5.md
@@ -210,7 +210,7 @@ This page does not have a title because the shadow root is not a [descendant](ht
 		</template>
 		<script>
       			const host = document.querySelector("body");
-      			const shadow = host.attachShadow({ mode: "closed" });
+      			const shadow = host.attachShadow({ mode: "open" });
       			const template = document.getElementById("shadow-element");
 
       			shadow.appendChild(template.content);

--- a/_rules/html-page-non-empty-title-2779a5.md
+++ b/_rules/html-page-non-empty-title-2779a5.md
@@ -198,6 +198,27 @@ This page has a `title` element that only contains a separator character.
 </html>
 ```
 
+#### Failed Example 6
+
+This page does not have a title because the shadow root is not a [descendant](https://dom.spec.whatwg.org/#concept-tree-descendant) of the [document element](https://dom.spec.whatwg.org/#document-element).
+
+```html
+<html>
+	<body>
+		<template id="shadow-element">
+			<title>This is the page title</title>
+		</template>
+		<script>
+      			const host = document.querySelector("body");
+      			const shadow = host.attachShadow({ mode: "closed" });
+      			const template = document.getElementById("shadow-element");
+
+      			shadow.appendChild(template.content);
+    		</script>
+	</body>
+</html>
+```
+
 ### Inapplicable
 
 #### Inapplicable Example 1


### PR DESCRIPTION
Closes issue(s): #2179

Description:
Adding a failed example of an HTML page lacking a title but featuring a shadow root with a non-empty `<title>` that does not affect the page title into the [HTML page has non-empty title [2779a5]](https://www.w3.org/WAI/standards-guidelines/act/rules/2779a5/) rule.


Need for Call for Review:
This will require a 1 week Call for Review 

---

## Pull Request Etiquette

### **When creating PR:**

- [ ] Make sure you're requesting to **pull a branch** (right side) to the `develop` branch (left side).
- [ ] Make sure you do not remove the "How to Review and Approve" section in your pull request description

### **After creating PR:**

- [ ] Add yourself (and co-authors) as "Assignees" for PR.
- [ ] Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- [ ] [Link the PR to any issue it solves](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue). This will be done automatically by [referencing the issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) at the top of this comment in the indicated place.
- [ ] Optionally request feedback from anyone in particular by assigning them as "Reviewers".

### **When merging a PR:**

- [ ] Close any issue that the PR resolves. This will happen automatically upon merging if the PR was correctly linked to the issue, e.g. by referencing the issue at the top of this comment.

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
