### PR TITLE
Updated ARIA state or property is permitted [5c01ea]: clarified global property is allowed except when prohibited and added examples

### DIFF
--- a/__tests__/spelling-ignore.yml
+++ b/__tests__/spelling-ignore.yml
@@ -239,6 +239,7 @@
 - unitless
 - luminance
 - disambiguated
+- superclass
 
 # Parts of Unicode
 - 000A

--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -109,7 +109,7 @@ The `aria-busy` [state][] is a [global][] [state][] that is [supported][] by all
 
 #### Passed Example 4
 
-The `aria-label` [property][] is a [global][] [property][]. It is allowed on any [semantic role][].
+The `aria-label` [property][] is a [global][] [property][]. It is allowed on any [semantic role][], except where specifically prohibited.
 
 ```html
 <div role="button" aria-label="OK">✓</div>
@@ -149,7 +149,7 @@ The `aria-controls` [property][] is [required][] for the [semantic][semantic rol
 
 #### Passed Example 9
 
-The `aria-label` [property][] is [global][]. It is allowed on any [semantic role][], including roles from the [WAI-ARIA Graphics Module](https://www.w3.org/TR/graphics-aria-1.0). This rule is applicable to SVG elements.
+The `aria-label` [property][] is [global][]. It is allowed on any [semantic role][], except where specifically prohibited, including roles from the [WAI-ARIA Graphics Module](https://www.w3.org/TR/graphics-aria-1.0). This rule is applicable to SVG elements.
 
 ```html
 <svg xmlns="http://www.w3.org/2000/svg" role="graphics-object" width="100" height="100" aria-label="yellow circle">
@@ -171,6 +171,29 @@ This `input` element does not have an [explicit role][] of `textbox`, but the `a
 
 ```html
 <label>Password<input type="password" aria-required="true"/></label>
+```
+
+#### Passed Example 12
+
+This `div` element has an [explicit role][] of `switch`; the `aria-required` [property][] is [inherited][] from the `checkbox` superclass role.
+
+```html
+<div role="switch" aria-checked="false" tabindex="0" aria-required="true">
+	<span class="label">Notifications</span>
+	<span class="switch" style="position: relative; display: inline-block; top: 6px; border: 2px solid black; border-radius: 12px; height: 20px; width: 40px;">
+		<span style="position: absolute; top: 2px; left: 2px; display: inline-block; border: 2px solid black; border-radius: 8px; height: 12px; width: 12px; background: black;"></span>
+	</span>
+	<span class="on" aria-hidden="true" style="display: none;">On</span>
+	<span class="off" aria-hidden="true">Off</span>
+</div>
+```
+
+#### Passed Example 13
+
+This `div` element has an [explicit role][] of `separator`. The `aria-valuemin`, `aria-valuemax` and `aria-valuenow` [properties][property] are [supported][] for the `separator` role when the element is [focusable][].
+
+```html
+<div role="separator" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" tabindex="0">My separator</div>
 ```
 
 ### Failed
@@ -197,6 +220,24 @@ The `aria-label` property is [prohibited][] for an element with a `generic` role
 
 ```html
 <div aria-label="Bananas"></div>
+```
+
+#### Failed Example 4
+
+The `aria-label` property is [prohibited][] for an element with a `paragraph` role.
+
+```html
+<div role="paragraph" aria-label="Bananas"></div>
+```
+
+#### Failed Example 5
+
+The `aria-valuemin`, `aria-valuemax` and `aria-valuenow` properties are not [supported][] for an element with a `separator` role that is not [focusable][].
+
+```html
+<div>ACT rules are cool!</div>
+<div style="border: 1px solid #000;" role="separator" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+<div>ACT rules are useful!</div>
 ```
 
 ### Inapplicable

--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -175,7 +175,7 @@ This `input` element does not have an [explicit role][] of `textbox`, but the `a
 
 #### Passed Example 12
 
-This `div` element has an [explicit role][] of `switch`; the `aria-required` [property][] is [inherited][] from the `checkbox` superclass role.
+This `div` element has an [explicit role][] of `switch`; the `aria-required` [property][] is [inherited][] from the `checkbox` [superclass](https://www.w3.org/TR/wai-aria-1.2/#superclassrole) role.
 
 ```html
 <div role="switch" aria-checked="false" tabindex="0" aria-required="true">

--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -230,16 +230,6 @@ The `aria-label` property is [prohibited][] for an element with a `paragraph` ro
 <div role="paragraph" aria-label="Bananas"></div>
 ```
 
-#### Failed Example 5
-
-The `aria-valuemin`, `aria-valuemax` and `aria-valuenow` properties are not [supported][] for an element with a `separator` role that is not [focusable][].
-
-```html
-<div>ACT rules are cool!</div>
-<div style="border: 1px solid #000;" role="separator" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
-<div>ACT rules are useful!</div>
-```
-
 ### Inapplicable
 
 #### Inapplicable Example 1

--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -175,7 +175,7 @@ This `input` element does not have an [explicit role][] of `textbox`, but the `a
 
 #### Passed Example 12
 
-This `div` element has an [explicit role][] of `switch`; the `aria-required` [property][] is [inherited][] from the `checkbox` [superclass](https://www.w3.org/TR/wai-aria-1.2/#superclassrole) role.
+This `div` element has an [explicit role][] of `switch`; the `aria-required` [property][] is [inherited][] from the `checkbox` [superclass role](https://www.w3.org/TR/wai-aria-1.2/#superclassrole).
 
 ```html
 <div role="switch" aria-checked="false" tabindex="0" aria-required="true">


### PR DESCRIPTION
Closes: #2191

Updates:
- I've amended examples like "The aria-label [property](https://www.w3.org/TR/wai-aria-1.2/#dfn-property) is a [global](https://www.w3.org/TR/wai-aria-1.2/#global_states) [property](https://www.w3.org/TR/wai-aria-1.2/#dfn-property). It is allowed on any [semantic role](https://www.w3.org/WAI/standards-guidelines/act/rules/5c01ea/proposed/#semantic-role)," adding "except where specifically prohibited". This clarification was necessary because certain semantic roles, such as [caption](https://www.w3.org/TR/wai-aria-1.2/#caption), [code](https://www.w3.org/TR/wai-aria-1.2/#code), [deletion](https://www.w3.org/TR/wai-aria-1.2/#deletion), [emphasis](https://www.w3.org/TR/wai-aria-1.2/#emphasis), [generic](https://www.w3.org/TR/wai-aria-1.2/#generic), [insertion](https://www.w3.org/TR/wai-aria-1.2/#insertion), [paragraph](https://www.w3.org/TR/wai-aria-1.2/#paragraph), [presentation](https://www.w3.org/TR/wai-aria-1.2/#presentation), [strong](https://www.w3.org/TR/wai-aria-1.2/#strong), [subscript](https://www.w3.org/TR/wai-aria-1.2/#subscript), and [superscript](https://www.w3.org/TR/wai-aria-1.2/#superscript), prohibit the use of aria-label.
- I've included a passed example demonstrating the inheritance of properties from a superclass role, as it was absent.
- I've included a failed example showcasing a *prohibited* global property to underscore the significance of the edit mentioned in the first bullet point.
- I've included an interesting example (both passing and failing) of the *separator* role, illustrating that it supports a specific property when focusable but not when static.

Need for Call for Review:
This will require a 2 weeks Call for Review

---

## Pull Request Etiquette

### **When creating PR:**

- [ ] Make sure you're requesting to **pull a branch** (right side) to the `develop` branch (left side).
- [ ] Make sure you do not remove the "How to Review and Approve" section in your pull request description

### **After creating PR:**

- [ ] Add yourself (and co-authors) as "Assignees" for PR.
- [ ] Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
- [ ] [Link the PR to any issue it solves](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue). This will be done automatically by [referencing the issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) at the top of this comment in the indicated place.
- [ ] Optionally request feedback from anyone in particular by assigning them as "Reviewers".

### **When merging a PR:**

- [ ] Close any issue that the PR resolves. This will happen automatically upon merging if the PR was correctly linked to the issue, e.g. by referencing the issue at the top of this comment.

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
