### PR TITLE
Add 2.1.3 to iframe focusable rule

### DIFF
--- a/_rules/iframe-with-interactive-content-in-tab-order-akn7bn.md
+++ b/_rules/iframe-with-interactive-content-in-tab-order-akn7bn.md
@@ -4,7 +4,7 @@ name: Iframe with interactive elements is not excluded from tab-order
 rules_format: 1.1
 rule_type: atomic
 description: |
-  This rule checks that `iframe` elements which contain an interactive (tabbable) element are not excluded from sequential focus navigation.
+  This rule checks that `iframe` elements which contain keyboard focusable elements are not excluded from sequential focus navigation.
 accessibility_requirements:
   wcag20:2.1.1: # Keyboard (A)
     forConformance: true

--- a/_rules/iframe-with-interactive-content-in-tab-order-akn7bn.md
+++ b/_rules/iframe-with-interactive-content-in-tab-order-akn7bn.md
@@ -11,6 +11,11 @@ accessibility_requirements:
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
+  wcag20:2.1.3: # Keyboard (No exceptions) (AAA)
+    forConformance: true
+    failed: not satisfied
+    passed: further testing needed
+    inapplicable: further testing needed
   wcag-technique:G202: # Ensuring keyboard control for all functionality
     forConformance: false
     failed: not satisfied


### PR DESCRIPTION
Closes https://github.com/act-rules/act-rules.github.io/issues/2026

- This added 2.1.3 Keyboard (No Exceptiosn) (AAA) to this rule.
- This seemed slightly better to me.

**IMPORTANT**: This is going to cause implementors to be inconsistent. That's why I'm using a 2 week review. It is incorrect for this rule not to fail 2.1.3 for the same reason that [Scrollable content can be reached with sequential focus navigation](https://www.w3.org/WAI/standards-guidelines/act/rules/0ssw9k/) fails 2.1.3. The only difference between 2.1.1 and 2.1.3 is an exception for path based input. That's not the case for this iframes or scrollable regions.

Need for Call for Review: 2 weeks

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
