### PR TITLE
[Editorial] - [5f99a7] ARIA attribute is defined in WAI-ARIA - Passed Example 2 improvement

### DIFF
--- a/_rules/aria-attr-defined-5f99a7.md
+++ b/_rules/aria-attr-defined-5f99a7.md
@@ -65,7 +65,7 @@ This `article` element has an `aria-atomic` attribute which is defined in [WAI-A
 This `div` element with a role of `dialog` has an `aria-modal` attribute which is defined in [WAI-ARIA Specifications][].
 
 ```html
-<div role="dialog" aria-modal="true">Contains modal content...</div>
+<div role="dialog" aria-modal="true" aria-label="Modal title">Contains modal content...</div>
 ```
 
 #### Passed Example 3


### PR DESCRIPTION
Closes issue(s): https://github.com/act-rules/act-rules.github.io/issues/2239

### Description:
This PR adds the required acc name to the element with explicit role="dialog" 
from
`<div role="dialog" aria-modal="true">Contains modal content...</div>`
to
`<div role="dialog" aria-modal="true" aria-label="Modal title">Contains modal content...</div>`

Need for Call for Review:
This will require a 1 week Call for Review

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
