### PR TITLE
[Editorial] - [a25f45] Headers attribute specified on a cell refers to cells in the same table element - Inapplicable Example 4 improvement

### DIFF
--- a/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
+++ b/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
@@ -371,7 +371,7 @@ The `table` is not [visible][] in page.
 The rule applies only to `headers` attribute within a `table` element.
 
 ```html
-<div role="table">
+<div role="table" aria-label="Projects status">
 	<div role="row">
 		<div role="columnheader" id="header1">Projects</div>
 		<div role="columnheader" id="header2">Exams</div>

--- a/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
+++ b/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
@@ -371,7 +371,7 @@ The `table` is not [visible][] in page.
 The rule applies only to `headers` attribute within a `table` element.
 
 ```html
-<div role="table" aria-label="Projects status">
+<div role="table" aria-label="Grades">
 	<div role="row">
 		<div role="columnheader" id="header1">Projects</div>
 		<div role="columnheader" id="header2">Exams</div>


### PR DESCRIPTION
Closes issue(s): https://github.com/act-rules/act-rules.github.io/issues/2243

### Description:
This PR adds the required acc name to the element with explicit role="table"
from
`<div role="table">...`
to
`<div role="table" aria-label="Projects status">...`

### Need for Call for Review:
This can be merged with 1 approval