### PR TITLE
[Editorial] - [in6db8] ARIA required ID references exist - Passed Example 2 improvement

### DIFF
--- a/_rules/aria-required-id-references-in6db8.md
+++ b/_rules/aria-required-id-references-in6db8.md
@@ -78,7 +78,7 @@ The `aria-controls` [attribute value][] of this `scrollbar` matches the `id` of 
 The `aria-controls` [attribute value][] of this expanded `combobox` matches the `id` of the `ul` element in the same document.
 
 ```html
-<label for="tag_combo">Tag</label>
+<label for="tag_combo" id="tag_label">Tag</label>
 <input
 	type="text"
 	id="tag_combo"
@@ -87,7 +87,7 @@ The `aria-controls` [attribute value][] of this expanded `combobox` matches the 
 	aria-controls="popup_listbox"
 	aria-activedescendant="selected_option"
 />
-<ul role="listbox" id="popup_listbox">
+<ul role="listbox" id="popup_listbox" aria-labelledby="tag_label">
 	<li role="option">Zebra</li>
 	<li role="option" id="selected_option">Zoom</li>
 </ul>


### PR DESCRIPTION
Closes issue(s): https://github.com/act-rules/act-rules.github.io/issues/2245

### Description:
This PR adds the required acc name to the element with explicit role="listbox"
from
```
<label for="tag_combo">Tag</label>
...
<ul role="listbox" id="popup_listbox">
```
to
```
<label for="tag_combo" id="tag_label">Tag</label>
...
<ul role="listbox" id="popup_listbox" aria-labelledby="tag_label">
```

### Need for Call for Review:
This can be merged with 1 approval