### PR TITLE
[Editorial] - [bc4a75] ARIA required owned elements - Passed Example 2 improvement

### DIFF
--- a/_rules/aria-required-owned-element-bc4a75.md
+++ b/_rules/aria-required-owned-element-bc4a75.md
@@ -80,7 +80,7 @@ This element with the `list` role only owns elements with the `listitem` role. T
 This element with the `grid` role only owns elements with the `row` role, and the element with the `row` role only owns elements with the `gridcell` role. The `row` role is one of the [required owned elements][] for `grid`, and `gridcell` is one of the [required owned elements][] for `row`.
 
 ```html
-<table role="grid">
+<table role="grid" aria-label="grid name">
 	<tr role="row">
 		<td role="gridcell">Item 1</td>
 	</tr>


### PR DESCRIPTION
Closes issue(s): #2248

### Description:
This PR adds the required acc name to the element with explicit role="grid"
from
```
<table role="grid">
	<tr role="row">
		<td role="gridcell">Item 1</td>
	</tr>
</table>
```
to
```
<table role="grid" aria-label="grid name">
	<tr role="row">
		<td role="gridcell">Item 1</td>
	</tr>
</table>
```

### Need for Call for Review:
This can be merged with 1 approval