### PR TITLE
[Editorial] - [674b10] Role attribute has valid value - Inapplicable Example 4 improvement

### DIFF
--- a/_rules/role-attribute-valid-value-674b10.md
+++ b/_rules/role-attribute-valid-value-674b10.md
@@ -167,7 +167,7 @@ This `role` attribute is empty ("").
 This `role` attribute is only [ASCII whitespace][].
 
 ```html
-<input type="text" role=" " />
+<input type="text" role=" " aria-label="field name"/>
 ```
 
 #### Inapplicable Example 5


### PR DESCRIPTION
Closes issue(s): https://github.com/act-rules/act-rules.github.io/issues/2252

### Description:
This PR adds the acc name to the input type text in inapplicable example 4
from
`<input type="text" role=" " />`

to
`<input type="text" role=" " aria-label="field name"/>`

### Need for Call for Review:
This can be merged with 1 approval