### PR TITLE
[Editorial] - [5c01ea] ARIA state or property is permitted - Passed Example 6-7-8 improvement

### DIFF
--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -129,7 +129,7 @@ The `aria-checked` [state][] is [required][] for the [semantic][semantic role] `
 The `aria-controls` [property][] is [required][] for the [semantic][semantic role] `combobox`.
 
 ```html
-<div role="combobox" aria-controls="id1" aria-expanded="false">My combobox</div>
+<div role="combobox" aria-controls="id1" aria-expanded="false" aria-label="My combobox">My combobox</div>
 ```
 
 #### Passed Example 7
@@ -137,7 +137,7 @@ The `aria-controls` [property][] is [required][] for the [semantic][semantic rol
 The `aria-controls` [property][] is [required][] for the [semantic][semantic role] `combobox`. [WAI-ARIA states and properties][wai-aria state or property] with empty value are still applicable to this rule.
 
 ```html
-<div role="combobox" aria-expanded="false" aria-controls>My combobox</div>
+<div role="combobox" aria-expanded="false" aria-controls aria-label="My combobox">My combobox</div>
 ```
 
 #### Passed Example 8
@@ -145,7 +145,7 @@ The `aria-controls` [property][] is [required][] for the [semantic][semantic rol
 The `aria-controls` [property][] is [required][] for the [semantic][semantic role] `combobox`. [WAI-ARIA states and properties][wai-aria state or property] with empty value (specified as an empty string) are still applicable to this rule.
 
 ```html
-<div role="combobox" aria-expanded="false" aria-controls="">My combobox</div>
+<div role="combobox" aria-expanded="false" aria-controls="" aria-label="My combobox">My combobox</div>
 ```
 
 #### Passed Example 9


### PR DESCRIPTION
Closes issue(s): https://github.com/act-rules/act-rules.github.io/issues/2254

### Description:
This PR adds the required acc name from author to the element with explicit role="combobox"
from
```
<div role="combobox" aria-controls="id1" aria-expanded="false">My combobox</div>
<div role="combobox" aria-expanded="false" aria-controls>My combobox</div>
<div role="combobox" aria-expanded="false" aria-controls="">My combobox</div>
```

to
```
<div role="combobox" aria-controls="id1" aria-expanded="false" aria-label="My combobox">My combobox</div>
<div role="combobox" aria-expanded="false" aria-controls aria-label="My combobox">My combobox</div>
<div role="combobox" aria-expanded="false" aria-controls="" aria-label="My combobox">My combobox</div>
```

### Need for Call for Review:
This can be merged with 1 approval