### PR TITLE
[Editorial] - [5c01ea] ARIA state or property is permitted - Inapplicable Example 1 improvement (acc name)

### DIFF
--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -207,7 +207,7 @@ The `aria-label` property is [prohibited][] for an element with a `generic` role
 This `div` element has no [WAI-ARIA state or property][].
 
 ```html
-<div role="region" aria-label="Region name">A region of content</div>
+<div role="group">A group of content</div>
 ```
 
 #### Inapplicable Example 2

--- a/_rules/aria-state-or-property-permitted-5c01ea.md
+++ b/_rules/aria-state-or-property-permitted-5c01ea.md
@@ -207,7 +207,7 @@ The `aria-label` property is [prohibited][] for an element with a `generic` role
 This `div` element has no [WAI-ARIA state or property][].
 
 ```html
-<div role="region">A region of content</div>
+<div role="region" aria-label="Region name">A region of content</div>
 ```
 
 #### Inapplicable Example 2


### PR DESCRIPTION
Closes issue(s): https://github.com/act-rules/act-rules.github.io/issues/2256

### Description:
This PR adds the required acc name to the element with explicit role="region"
from
`<div role="region">A region of content</div>`

to
`<div role="region" aria-label="Region name">A region of content</div>`

### Need for Call for Review:
This can be merged with 1 approval