### PR TITLE
[Editorial] - [4e8ab6] Element with role attribute has required states and properties - Passed Example 6 improvement (acc name)

### DIFF
--- a/_rules/role-required-states-and-properties-4e8ab6.md
+++ b/_rules/role-required-states-and-properties-4e8ab6.md
@@ -119,9 +119,9 @@ This `separator` is not a `widget` because it is not [focusable][]. The `separat
 This `combobox` has the required properties `aria-controls` and `aria-expanded`.
 
 ```html
-<label for="tag_combo">Tag</label>
-<input type="text" id="tag_combo" role="combobox" aria-expanded="true" aria-controls="popup_listbox" />
-<ul role="listbox" id="popup_listbox">
+<label for="tag_combo" id="tag_label">Tag</label>
+<input type="text" id="tag_combo" role="combobox" aria-expanded="true" aria-controls="popup_listbox"/>
+<ul role="listbox" id="popup_listbox" aria-labelledby="tag_label">
 	<li role="option">Zebra</li>
 	<li role="option" id="selected_option">Zoom</li>
 </ul>


### PR DESCRIPTION
Closes issue(s): https://github.com/act-rules/act-rules.github.io/issues/2262

### Description:
This PR adds the required acc name to the element with explicit role="listbox"
from
```
<label for="tag_combo">Tag</label>
<input type="text" id="tag_combo" role="combobox" aria-expanded="true" aria-controls="popup_listbox" />
<ul role="listbox" id="popup_listbox">
	<li role="option">Zebra</li>
	<li role="option" id="selected_option">Zoom</li>
</ul>
```

to
```
<label for="tag_combo" id="tag_label">Tag</label>
<input type="text" id="tag_combo" role="combobox" aria-expanded="true" aria-controls="popup_listbox"/>
<ul role="listbox" id="popup_listbox" aria-labelledby="tag_label">
	<li role="option">Zebra</li>
	<li role="option" id="selected_option">Zoom</li>
</ul>
```

### Need for Call for Review:
This can be merged with 1 approval