### PR TITLE
[Editorial] - [4e8ab6] Element with role attribute has required states and properties - Inapplicable Example 2 improvement (acc name)

### DIFF
--- a/_rules/role-required-states-and-properties-4e8ab6.md
+++ b/_rules/role-required-states-and-properties-4e8ab6.md
@@ -209,7 +209,7 @@ This `div` does not have a [semantic role](#semantic-role).
 This `checkbox` has an [implicit semantic role](#implicit-role) that is identical to the [explicit semantic role](#explicit-role). This allows native HTML `checked` attribute to apply.
 
 ```html
-<input type="checkbox" role="checkbox" />
+<input type="checkbox" role="checkbox" aria-label="Checkbox name"/>
 ```
 
 #### Inapplicable Example 3


### PR DESCRIPTION
Closes issue(s): https://github.com/act-rules/act-rules.github.io/issues/2264

### Description:
This PR adds the required acc name to the checkbox element
from
`<input type="checkbox" role="checkbox" />`
to
`<input type="checkbox" role="checkbox" aria-label="Checkbox name"/>`

### Need for Call for Review:
This can be merged with 1 approval