### PR TITLE
[Editorial] - [d0f69e] Table header cell has assigned cells - Passed Example 2-4 improvement (acc name)

### DIFF
--- a/_rules/table-header-cell-has-assigned-cells-d0f69e.md
+++ b/_rules/table-header-cell-has-assigned-cells-d0f69e.md
@@ -80,7 +80,7 @@ This `th` element has an assigned `td` element.
 Each of the 2 `span` elements with role of `columnheader` has assigned `span` elements with a role of `cell`.
 
 ```html
-<div role="table">
+<div role="table" aria-label="Temperatures">
 	<div role="rowgroup">
 		<div role="row">
 			<span role="columnheader">Month</span>
@@ -125,7 +125,7 @@ Each of the 2 `th` elements has an assigned `td` element because this `td` eleme
 Each of the 4 `th` elements has an assigned `td` element, within the same `table` element having a [semantic role][] of `grid`.
 
 ```html
-<table role="grid">
+<table role="grid" aria-label="Meal times">
 	<thead>
 		<tr>
 			<td></td>


### PR DESCRIPTION
Closes issue(s): https://github.com/act-rules/act-rules.github.io/issues/2266

### Description:
This PR adds the required acc name to the elements with explicit table and grid roles.
from
`<div role="table">`
and
`<table role="grid">`

to
`<div role="table" aria-label="Temperatures">`
and
`<table role="grid" aria-label="Meal times">`

### Need for Call for Review:
This can be merged with 1 approval