### PR TITLE
[Accessibility support] - Empty alt attribute is now consistently supported

### DIFF
--- a/_rules/image-non-empty-accessible-name-23a2a8.md
+++ b/_rules/image-non-empty-accessible-name-23a2a8.md
@@ -55,7 +55,6 @@ There are no assumptions.
 
 ### Accessibility Support
 
-- There are several popular browsers that do not treat images with an empty `alt` attribute (`alt=""`) as having a role of `presentation` but instead add the `img` element to the accessibility tree with a [semantic role][] of either `img` or `graphic`.
 - Implementation of [Presentational Roles Conflict Resolution][] varies from one browser or assistive technology to another. Depending on this, some [semantic][semantic role] `img` elements can fail this rule with some technology but users of other technologies would not experience any accessibility issue.
 - Images can have their role set to `presentation` through an empty `alt` attribute. [Presentational Roles Conflict Resolution][] does not specify what to do if such an image is [focusable][] (it only specifies what to do in case of explicit `role="none"` or `role="presentation"`). Some browsers expose these images and some don't. Thus, this rule may fail for technologies that expose these without creating an accessibility issue for users of other technologies.
 


### PR DESCRIPTION
Closes: https://github.com/act-rules/act-rules.github.io/issues/2273

### Description:
I've removed the following accessibility support note from [Image has non-empty accessible name - 23a2a8](https://www.w3.org/WAI/standards-guidelines/act/rules/23a2a8/)

> There are several popular browsers that do not treat images with an empty alt attribute (alt="") as having a role of presentation but instead add the img element to the accessibility tree with a [semantic role](https://www.w3.org/WAI/standards-guidelines/act/rules/23a2a8/#semantic-role) of either img or graphic.

Since it's quite few years this is no longer true.

### Need for Call for Review:
This will require a 2 weeks Call for Review 