### PR TITLE
Unnecessary autocomplete support item

### DIFF
--- a/_rules/autocomplete-valid-value-73f2c2.md
+++ b/_rules/autocomplete-valid-value-73f2c2.md
@@ -69,7 +69,6 @@ The purpose of a control is programmatically identifiable even when its `autocom
 
 - While `autocomplete` is a promising technique for supporting personalization in HTML, support for this in assistive technologies is fairly limited.
 - Implementation of [Presentational Roles Conflict Resolution][] varies from one browser or assistive technology to another. Depending on this, some elements can have a [semantic role][] of `none` and fail this rule with some technology but users of other technologies would not experience any accessibility issue.
-- In some user agents, querying the value of the `autocomplete` property returns an empty string ("") even when the attribute was set according to the rule's expectations. It affects assistive technologies which rely on this property to personalize input fields collecting information about the user.
 - Authors may assign inappropriate `autocomplete` attribute values. Moreover, HTML specifications restrict certain `autocomplete` attribute values to specific form controls. Mismatches between `autocomplete` attribute values and form control types may or may not lead to a failure of [success criterion 1.3.5 Identify Input Purpose](https://www.w3.org/TR/WCAG22/#identify-input-purpose). However, this rule focuses exclusively on validating valid `autocomplete` attribute values, disregarding their contextual appropriateness.
 
 ### Bibliography


### PR DESCRIPTION
Noticed this one reviewing our support items. This looks like it might have been added by some misunderstanding on our part, not something that was a problem in browsers.

The issue here related to form elements with autocomplete=off, but as far as I can tell that does not result in `elm.autocomplete === ''` when the autocomplete is otherwise set.


Need for Call for Review: none, small change
---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
