### PR TITLE
Direct Netlify setup for PR preview deploys

### DIFF
--- a/.github/scripts/pr-preview.mjs
+++ b/.github/scripts/pr-preview.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env zx
+import 'zx/globals';
+import { config, cloneWcagActRules, commitAndPush } from './commons.mjs'
+
+await cloneWcagActRules(config);
+await generateProposedRulePages(config);
+await generateTestCases(config);
+// const commitMessage = (await $`git log -1 --pretty=%B`).stdout;
+// await commitAndPush(config, commitMessage);
+
+async function generateProposedRulePages({ tmpDir, rulesDir, glossaryDir, testAssetsDir }) {
+  await $`node ./node_modules/act-tools/dist/cli/rule-transform.js \
+  --rulesDir "${rulesDir}" \
+  --glossaryDir "${glossaryDir}" \
+  --testAssetsDir "${testAssetsDir}" \
+  --outDir "${tmpDir}" \
+  --proposed
+  `;
+}
+
+async function generateTestCases({ tmpDir, rulesDir, testAssetsDir }) {
+  await $`node ./node_modules/act-tools/dist/cli/build-examples.js \
+    --rulesDir "${rulesDir}" \
+    --testAssetsDir "${testAssetsDir}" \
+    --outDir "${tmpDir}" \
+    --proposed
+  `;
+}

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ yarn.lock
 
 # Tmp build directory
 wcag-act-rules-tmp/
+
+# Local Netlify folder
+.netlify

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,15 @@
+[build]
+command = "npm run pr:preview && cd wcag-act-rules-tmp && git submodule update --init --remote && bundle install && bundle exec jekyll build --config '_config.yml,_config_staging.yml'"
+# base = "wcag-act-rules-tmp"
+publish = "wcag-act-rules-tmp/_site"
+
+[build.environment]
+# RUBY_VERSION = "3.3.3"
+
+[[redirects]]
+  from = "/"
+  to = "/standards-guidelines/act/rules/"
+
+[[redirects]]
+  from = "/standards-guidelines/act/rules/*"
+  to = "/standards-guidelines/at/rules/:splat/proposed"

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "npm run pr:preview && cd wcag-act-rules-tmp && git submodule update -
 publish = "wcag-act-rules-tmp/_site"
 
 [build.environment]
-# RUBY_VERSION = "3.3.3"
+RUBY_VERSION = "3.3.3"
 
 [[redirects]]
   from = "/"

--- a/package.json
+++ b/package.json
@@ -177,7 +177,8 @@
 		"formatRulesDir": "prettier --write './_rules/**/*.md'",
 		"format": "prettier --write *.{json,md,js,html,css,yml} './{__tests__,_rules,.github,pages,test-assets,test-utils,utils}/**/*.{json,md,js,html,css,yml}'",
 		"test": "jest --coverage",
-		"build:wai": "zx .github/scripts/wai-build.mjs"
+		"build:wai": "zx .github/scripts/wai-build.mjs",
+		"pr:preview": "zx .github/scripts/pr-preview.mjs"
 	},
 	"homepage": "https://github.com/act-rules/act-rules.github.io",
 	"repository": {


### PR DESCRIPTION
This sets up the Netlify preview to run directly on the Netlify CI/CD servers instead of pushing to w3c/wcag-act-rules every time we open a PR.