### PR TITLE
[a25f45] Headers attribute specified on a cell refers to cells in the same table element - Updated Inapplicable Example 6

### DIFF
--- a/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
+++ b/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
@@ -405,7 +405,7 @@ The `table` is not [included in the accessibility tree][].
 This `table` doesn't have a role of `table`, `grid` or `treegrid`.
 
 ```html
-<table role="region">
+<table role="region" aria-label="Hello">
 	<td id="self" headers="self">World</td>
 </table>
 ```

--- a/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
+++ b/_rules/table-headers-attribute-refer-to-data-cells-a25f45.md
@@ -405,7 +405,7 @@ The `table` is not [included in the accessibility tree][].
 This `table` doesn't have a role of `table`, `grid` or `treegrid`.
 
 ```html
-<table role="region" aria-label="Hello">
+<table role="heading" aria-level="1">
 	<td id="self" headers="self">World</td>
 </table>
 ```


### PR DESCRIPTION
Closes issue: #2268 

Role region without acc name is ignored.
Added an aria-label attribute to the `table` element with role `region` so that the table is exposed as a region rather than a table (that is currently invalidating the example, by making it applicable).

Need for Call for Review:
This will require a 1 week Call for Review 

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
