### PR TITLE
[4e8ab6] Element with role attribute has required states and properties - Removed Combobox Failed Example 6

### DIFF
--- a/_rules/role-required-states-and-properties-4e8ab6.md
+++ b/_rules/role-required-states-and-properties-4e8ab6.md
@@ -181,19 +181,6 @@ This `combobox` does not have the required `aria-expanded` property. Prior to [W
 </ul>
 ```
 
-#### Failed Example 6
-
-This `combobox` uses `aria-owns` instead of using the required `aria-controls` property.
-
-```html
-<label for="tag_combo">Tag</label>
-<input type="text" id="tag_combo" role="combobox" aria-expanded="true" aria-owns="popup_listbox" />
-<ul role="listbox" id="popup_listbox">
-	<li role="option">Zebra</li>
-	<li role="option" id="selected_option">Zoom</li>
-</ul>
-```
-
 ### Inapplicable
 
 #### Inapplicable Example 1


### PR DESCRIPTION
Closes issue: #2310

ARIA has removed the aria-controls requirement from combobox, so failed example 6 has been removed. 

Need for Call for Review:
This will require a 1 week Call for Review 

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
