### PR TITLE
Update the aria-required-owned rule [bc4a75] to include the elements with implicit roles 

### DIFF
--- a/_rules/aria-required-owned-element-bc4a75.md
+++ b/_rules/aria-required-owned-element-bc4a75.md
@@ -27,7 +27,7 @@ acknowledgments:
 
 ## Applicability
 
-This rule applies to any [HTML or SVG element][] that is [included in the accessibility tree][] and has a [WAI-ARIA 1.2][] [explicit or implicit semantic role][] with [required owned elements][], except if the element has an [inclusive ancestor][] in the accessibility tree with an `aria-busy` [attribute value][] of `true`.
+This rule applies to any [HTML or SVG element][] that is [included in the accessibility tree][] and has a [WAI-ARIA 1.2][] [semantic role][] with [required owned elements][], except if the element has an [inclusive ancestor][] in the accessibility tree with an `aria-busy` [attribute value][] of `true`.
 
 ## Expectation
 

--- a/_rules/aria-required-owned-element-bc4a75.md
+++ b/_rules/aria-required-owned-element-bc4a75.md
@@ -27,7 +27,7 @@ acknowledgments:
 
 ## Applicability
 
-This rule applies to any [HTML or SVG element][] that is [included in the accessibility tree][] and has a [WAI-ARIA 1.2][] [explicit semantic role][] with [required owned elements][], except if the element has an [inclusive ancestor][] in the accessibility tree with an `aria-busy` [attribute value][] of `true`.
+This rule applies to any [HTML or SVG element][] that is [included in the accessibility tree][] and has a [WAI-ARIA 1.2][] [explicit or implicit semantic role][] with [required owned elements][], except if the element has an [inclusive ancestor][] in the accessibility tree with an `aria-busy` [attribute value][] of `true`.
 
 ## Expectation
 
@@ -93,8 +93,8 @@ This element with the `menu` role only owns elements with the `menuitem`, `menui
 
 ```html
 <div role="menu">
-	<li role="none"></li>
-	<li role="menuitem">Item 1</li>
+	<div role="none"></li>
+	<div role="menuitem">Item 1</li>
 	<div role="menuitemradio" aria-checked="false">Item 2</div>
 	<div role="menuitemcheckbox" aria-checked="false">Item 3</div>
 </div>
@@ -137,6 +137,16 @@ This element with the `menu` role only owns an element with a `group` role. The 
 		</div>
 	</div>
 </div>
+```
+
+#### Passed Example 7
+
+The element `ul` with an implicit `list` role owns an element `li` with an implicit role `listitem` role.
+
+```html
+<ul>
+	<li>Item 1</li>
+</ul>
 ```
 
 ### Failed
@@ -237,11 +247,11 @@ This element with the `list` role is not included in the accessibility tree beca
 
 #### Inapplicable Example 2
 
-This `ul` element does not have an [explicit semantic role][].
+This `div` element with the `list` role is not included in the accessibility tree because it is hidden .
 
 ```html
-<ul>
-	<li>Item 1</li>
+<div role='list' hidden>
+	<div role='listitem'>Item 1</li>
 </ul>
 ```
 

--- a/_rules/aria-required-owned-element-bc4a75.md
+++ b/_rules/aria-required-owned-element-bc4a75.md
@@ -4,7 +4,7 @@ name: ARIA required owned elements
 rules_format: 1.1
 rule_type: atomic
 description: |
-  This rule checks that an element with an explicit semantic role has at least one of its required owned elements.
+  This rule checks that an element with a semantic role has at least one of its required owned elements.
 accessibility_requirements:
   wcag20:1.3.1: # Info and Relationships (A)
     forConformance: true
@@ -161,7 +161,7 @@ The element `select` with an implicit `listbox` role owns elements `option` with
 </select>
 ```
 
-#### Passed Example 8
+#### Passed Example 9
 
 The element `table` with an implicit `table` role owns an element `tr` with implicit `row` role that owns elements `td` with implicit `cell` roles.
 
@@ -339,4 +339,3 @@ This element with the `menu` role has an `aria-busy` attribute set to `true`.
 [wai-aria graphics module]: https://www.w3.org/TR/graphics-aria-1.0/ 'WAI-ARIA Graphics Module 1.0'
 [html or svg element]: #namespaced-element
 [inclusive ancestor]: https://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor 'DOM Definition of Inclusive Ancestor'
-[implicit wai-aria semantics]: https://w3c.github.io/aria/#implicit_semantics

--- a/_rules/aria-required-owned-element-bc4a75.md
+++ b/_rules/aria-required-owned-element-bc4a75.md
@@ -180,7 +180,7 @@ The element `table` with an implicit `table` role owns an element `tr` with impl
 The element `table` with an explicit `treegrid` role owns an element `tr` with implicit `row` role that in turn owns elements `td` with implicit `gridcell` roles.
 
 ```html
-<table role="treegrid">
+<table role="treegrid" aria-label="a test grid">
 	<tr>
 		<td>Item 1</td>
 		<td>Item 2</td>
@@ -280,7 +280,7 @@ This element with the `list` role owns an element with the `listitem` role and a
 This element with the `menu` role owns `option` elements with implicit `option` role. The `option` role is not one of the [required owned elements][] for `menu`.
 
 ```html
-<select role="menu">
+<select role="menu" aria-label="a test menu">
 	<option>Item 1</option>
 	<option>Item 2</option>
 	<option>Item 3</option>
@@ -289,14 +289,14 @@ This element with the `menu` role owns `option` elements with implicit `option` 
 
 #### Failed Example 9
 
-This element with the `menu` role owns `tr` elements with implicit `row` role. The `row` role is not one of the [required owned elements][] for `menu`. In addition, the `tr` element with implicit `row` role owns `td` elements with explicit `menuitem` roles. The `menuitem` role is not one of the [required owned elements][] for `row`.
+This element with the `menu` role owns `tr` elements with an explicit `list` role. The `list` role is not one of the [required owned elements][] for `menu`. In addition, the `tr` element with the explicit `list` role owns `td` elements with explicit `menuitem` roles. The `menuitem` role is not one of the [required owned elements][] for `list`.
 
 ```html
-<table role="menu">
-	<tr>
-		<td role="menuitem">Item 1</td>
-		<td role="menuitem">Item 2</td>
-		<td role="menuitem">Item 3</td>
+<table role="menu" aria-label="a test table" aria-activedescendant="item1" tabindex="0">
+	<tr role="list">
+		<td id="item1" role="menuitem">Item 1</td>
+		<td id="item2" role="menuitem">Item 2</td>
+		<td id="item3" role="menuitem">Item 3</td>
 	</tr>
 </table>
 ```

--- a/_rules/aria-required-owned-element-bc4a75.md
+++ b/_rules/aria-required-owned-element-bc4a75.md
@@ -250,9 +250,9 @@ This element with the `list` role is not included in the accessibility tree beca
 This `div` element with the `list` role is not included in the accessibility tree because it is hidden .
 
 ```html
-<div role='list' hidden>
-	<div role='listitem'>Item 1</div>
-</ul>
+<div role="list" hidden>
+	<div role="listitem">Item 1</div>
+</div>
 ```
 
 #### Inapplicable Example 3

--- a/_rules/aria-required-owned-element-bc4a75.md
+++ b/_rules/aria-required-owned-element-bc4a75.md
@@ -93,8 +93,8 @@ This element with the `menu` role only owns elements with the `menuitem`, `menui
 
 ```html
 <div role="menu">
-	<div role="none"></li>
-	<div role="menuitem">Item 1</li>
+	<div role="none"></div>
+	<div role="menuitem">Item 1</div>
 	<div role="menuitemradio" aria-checked="false">Item 2</div>
 	<div role="menuitemcheckbox" aria-checked="false">Item 3</div>
 </div>
@@ -251,7 +251,7 @@ This `div` element with the `list` role is not included in the accessibility tre
 
 ```html
 <div role='list' hidden>
-	<div role='listitem'>Item 1</li>
+	<div role='listitem'>Item 1</div>
 </ul>
 ```
 

--- a/_rules/aria-required-owned-element-bc4a75.md
+++ b/_rules/aria-required-owned-element-bc4a75.md
@@ -45,7 +45,7 @@ The applicability of this rule is limited to the [WAI-ARIA 1.2 Recommendation][w
 
 ### Assumptions
 
-If the [explicit semantic role][] on the target element is incorrectly used, and any relationships between elements are already programmatically determinable, failing this rule may not result in accessibility issues for users of assistive technologies, and it should then not be considered a failure under [WCAG success criterion 1.3.1 Info and Relationships](https://www.w3.org/TR/WCAG22/#info-and-relationships).
+If the [semantic role][] on the target element is incorrectly used, and any relationships between elements are already programmatically determinable, failing this rule may not result in accessibility issues for users of assistive technologies, and it should then not be considered a failure under [WCAG success criterion 1.3.1 Info and Relationships](https://www.w3.org/TR/WCAG22/#info-and-relationships).
 
 ### Accessibility Support
 
@@ -102,7 +102,7 @@ This element with the `menu` role only owns elements with the `menuitem`, `menui
 
 #### Passed Example 4
 
-This element with the `tablist` role only owns elements with the `tab` role. The `tab` role is one of the [required owned elements][] for `tablist`. The `li` element is ignored because it has an [explicit semantic role][] of `none`.
+This element with the `tablist` role only owns elements with the `tab` role. The `tab` role is one of the [required owned elements][] for `tablist`. The `li` element is ignored because it has an [semantic role][] of `none`.
 
 ```html
 <ul role="tablist">
@@ -345,7 +345,6 @@ This element with the `menu` role has an `aria-busy` attribute set to `true`.
 [required owned elements]: https://www.w3.org/TR/wai-aria-1.2/#mustContain 'Define Required owned element'
 [owns]: #owned-by
 [owned by]: #owned-by
-[explicit semantic role]: #explicit-role
 [semantic role]: #semantic-role
 [included in the accessibility tree]: #included-in-the-accessibility-tree
 [wai-aria 1.2]: https://www.w3.org/TR/wai-aria-1.2/

--- a/_rules/aria-required-owned-element-bc4a75.md
+++ b/_rules/aria-required-owned-element-bc4a75.md
@@ -301,6 +301,17 @@ This element with the `menu` role owns `tr` elements with an explicit `list` rol
 </table>
 ```
 
+#### Failed Example 10
+
+This element with the implicit `list` role owns an element with the implicit `generic` role. The `generic` role is not one of the [required owned elements][] for `list`. Note that this example is for demonstration purpose only because it's not a valid HTML 5 structure.
+
+```html
+<ul>
+	<div></div>
+	<div></div>
+</ul>
+```
+
 ### Inapplicable
 
 #### Inapplicable Example 1

--- a/_rules/aria-required-owned-element-bc4a75.md
+++ b/_rules/aria-required-owned-element-bc4a75.md
@@ -163,10 +163,24 @@ The element `select` with an implicit `listbox` role owns elements `option` with
 
 #### Passed Example 9
 
-The element `table` with an implicit `table` role owns an element `tr` with implicit `row` role that owns elements `td` with implicit `cell` roles.
+The element `table` with an implicit `table` role owns an element `tr` with implicit `row` role that in turn owns elements `td` with implicit `cell` roles.
 
 ```html
 <table>
+	<tr>
+		<td>Item 1</td>
+		<td>Item 2</td>
+		<td>Item 3</td>
+	</tr>
+</table>
+```
+
+#### Passed Example 10
+
+The element `table` with an explicit `treegrid` role owns an element `tr` with implicit `row` role that in turn owns elements `td` with implicit `gridcell` roles.
+
+```html
+<table role="treegrid">
 	<tr>
 		<td>Item 1</td>
 		<td>Item 2</td>

--- a/_rules/aria-required-owned-element-bc4a75.md
+++ b/_rules/aria-required-owned-element-bc4a75.md
@@ -141,12 +141,38 @@ This element with the `menu` role only owns an element with a `group` role. The 
 
 #### Passed Example 7
 
-The element `ul` with an implicit `list` role owns an element `li` with an implicit role `listitem` role.
+The element `ul` with an implicit `list` role owns an element `li` with an implicit `listitem` role.
 
 ```html
 <ul>
 	<li>Item 1</li>
 </ul>
+```
+
+#### Passed Example 8
+
+The element `select` with an implicit `listbox` role owns elements `option` with implicit `option` roles.
+
+```html
+<select multiple>
+	<option>Item 1</option>
+	<option>Item 2</option>
+	<option>Item 3</option>
+</select>
+```
+
+#### Passed Example 8
+
+The element `table` with an implicit `table` role owns an element `tr` with implicit `row` role that owns elements `td` with implicit `cell` roles.
+
+```html
+<table>
+	<tr>
+		<td>Item 1</td>
+		<td>Item 2</td>
+		<td>Item 3</td>
+	</tr>
+</table>
 ```
 
 ### Failed
@@ -235,6 +261,32 @@ This element with the `list` role owns an element with the `listitem` role and a
 </div>
 ```
 
+#### Failed Example 8
+
+This element with the `menu` role owns `option` elements with implicit `option` role. The `option` role is not one of the [required owned elements][] for `menu`.
+
+```html
+<select role="menu">
+	<option>Item 1</option>
+	<option>Item 2</option>
+	<option>Item 3</option>
+</select>
+```
+
+#### Failed Example 9
+
+This element with the `menu` role owns `tr` elements with implicit `row` role. The `row` role is not one of the [required owned elements][] for `menu`. In addition, the `tr` element with implicit `row` role owns `td` elements with explicit `menuitem` roles. The `menuitem` role is not one of the [required owned elements][] for `row`.
+
+```html
+<table role="menu">
+	<tr>
+		<td role="menuitem">Item 1</td>
+		<td role="menuitem">Item 2</td>
+		<td role="menuitem">Item 3</td>
+	</tr>
+</table>
+```
+
 ### Inapplicable
 
 #### Inapplicable Example 1
@@ -287,3 +339,4 @@ This element with the `menu` role has an `aria-busy` attribute set to `true`.
 [wai-aria graphics module]: https://www.w3.org/TR/graphics-aria-1.0/ 'WAI-ARIA Graphics Module 1.0'
 [html or svg element]: #namespaced-element
 [inclusive ancestor]: https://dom.spec.whatwg.org/#concept-tree-inclusive-ancestor 'DOM Definition of Inclusive Ancestor'
+[implicit wai-aria semantics]: https://w3c.github.io/aria/#implicit_semantics


### PR DESCRIPTION
The original description limits the rule to the elements with explicit semantic roles only.  The rule should apply to elements with either explicit or implicit roles. 
The changes include the following updates: (1) the description of implicit roles; (2) test cases accordingly; and (3) other minor code cleanups.  

Need for Call for Review:
This can be merged with 1 approval 

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
