### PR TITLE
summary name, element position clarified

### DIFF
--- a/_rules/summary-non-empty-accessible-name-2t702h.md
+++ b/_rules/summary-non-empty-accessible-name-2t702h.md
@@ -34,7 +34,7 @@ Each target element has an [accessible name][] that is not empty (`""`), nor jus
 
 ## Background
 
-This rule is only applicable to `summary` elements that the browser will use as controls for a `details` element. While this rule is not applicable to `summary` elements with an [explicit role][], most of the time these likely do still require an [accessible name][]. This is covered by other rules, such as the [Button has non-empty accessible name][97a4e1].
+This rule is only applicable to `summary` elements that the browser will use as controls for a `details` element. Even though the [HTML specification - The summary element][https://html.spec.whatwg.org/#the-summary-element] requires the `summary` element to be the first child of `details`, this is not required for WCAG. And while this rule is not applicable to `summary` elements with an [explicit role][], most of the time these likely do still require an [accessible name][]. This is covered by other rules, such as the [Button has non-empty accessible name][97a4e1].
 
 If the `summary` element is not included in the accessibility tree, but is still included in sequential focus navigation, this can result in accessibility issues not tested by this rule. This is covered under [Element with aria-hidden has no content in sequential focus navigation][6cfa84].
 

--- a/_rules/summary-non-empty-accessible-name-2t702h.md
+++ b/_rules/summary-non-empty-accessible-name-2t702h.md
@@ -34,7 +34,7 @@ Each target element has an [accessible name][] that is not empty (`""`), nor jus
 
 ## Background
 
-This rule is only applicable to `summary` elements that the browser will use as controls for a `details` element. Even though the [HTML specification - The summary element][https://html.spec.whatwg.org/#the-summary-element] requires the `summary` element to be the first child of `details`, this is not required for WCAG. And while this rule is not applicable to `summary` elements with an [explicit role][], most of the time these likely do still require an [accessible name][]. This is covered by other rules, such as the [Button has non-empty accessible name][97a4e1].
+This rule is only applicable to `summary` elements that the browser will use as controls for a `details` element. Even though the [HTML specification - The summary element](https://html.spec.whatwg.org/#the-summary-element) requires the `summary` element to be the first child of `details`, this is not required for WCAG. And while this rule is not applicable to `summary` elements with an [explicit role][], most of the time these likely do still require an [accessible name][]. This is covered by other rules, such as the [Button has non-empty accessible name][97a4e1].
 
 If the `summary` element is not included in the accessibility tree, but is still included in sequential focus navigation, this can result in accessibility issues not tested by this rule. This is covered under [Element with aria-hidden has no content in sequential focus navigation][6cfa84].
 


### PR DESCRIPTION
Adds clarification on how the `summary` element can be used since HTML specification requires the `summary` element to be the first child of `details`, while WCAG does not.

This will not require a Call for Review : editorial changes to background

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
