### PR TITLE
[4e8ab6] Fix aria mapping on the "Element with role attribute has required states and properties" rule

### DIFF
--- a/_rules/role-required-states-and-properties-4e8ab6.md
+++ b/_rules/role-required-states-and-properties-4e8ab6.md
@@ -11,7 +11,7 @@ accessibility_requirements:
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
-  aria12:requiredState: # 5.2.2 Required States and Properties
+  aria12:requiredState:
     title: ARIA 1.2, 5.2.2 Required States and Properties
     forConformance: true
     failed: not satisfied

--- a/_rules/role-required-states-and-properties-4e8ab6.md
+++ b/_rules/role-required-states-and-properties-4e8ab6.md
@@ -12,6 +12,7 @@ accessibility_requirements:
     passed: further testing needed
     inapplicable: further testing needed
   aria12:requiredState: # 5.2.2 Required States and Properties
+    title: ARIA 1.2, 5.2.2 Required States and Properties
     forConformance: true
     failed: not satisfied
     passed: satisfied


### PR DESCRIPTION
Fix aria mapping on the "Element with role attribute has required states and properties" rule since the aria title is required. Test will be added in a separate PR since the fix is urgent.


Closes issue(s):

- closes https://github.com/act-rules/act-rules.github.io/issues/2324

Need for Call for Review:
This will not require a Call for Review: Accessibility Requirements Mapping fix

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
