### PR TITLE
Add test for validating aria properties for `accessibility_requirements`

### DIFF
--- a/__tests__/frontmatter.js
+++ b/__tests__/frontmatter.js
@@ -133,7 +133,7 @@ function validateAriaProperties(accessibilityRequirements) {
 		expect(aria12Key.split(':')[1]).toBeTruthy()
 
 		// Check that aria object has the required properties
-		const requiredAriaProps = ['title', 'forConformance', 'failed', 'passed']
+		const requiredAriaProps = ['title', 'forConformance', 'failed', 'passed', 'inapplicable']
 		test.each(requiredAriaProps)('has required property `%s`', requiredProp => {
 			expect(accessibilityRequirements[aria12Key]).toHaveProperty(requiredProp)
 		})

--- a/__tests__/frontmatter.js
+++ b/__tests__/frontmatter.js
@@ -1,7 +1,7 @@
 const describeRule = require('../test-utils/describe-rule')
 const describePage = require('../test-utils/describe-page')
 
-describe.only('frontmatter', () => {
+describe('frontmatter', () => {
 	/**
 	 * Rules
 	 */

--- a/__tests__/frontmatter.js
+++ b/__tests__/frontmatter.js
@@ -1,7 +1,7 @@
 const describeRule = require('../test-utils/describe-rule')
 const describePage = require('../test-utils/describe-page')
 
-describe('frontmatter', () => {
+describe.only('frontmatter', () => {
 	/**
 	 * Rules
 	 */
@@ -90,6 +90,7 @@ function validateRuleFrontmatter({ frontmatter }, metaData) {
 	 * Check if `accessibility_requirements` (if any) has expected values
 	 */
 	if (accessibility_requirements) {
+		validateAriaProperties(accessibility_requirements)
 		/**
 		 * The below check the `values` for every `key - value` pair of accessibility requirements
 		 */
@@ -122,4 +123,19 @@ function validateGlossaryFrontmatter({ frontmatter }) {
 	test.each(requiredProps)('has required property `%s`', requiredProp => {
 		expect(frontmatter).toHaveProperty(requiredProp)
 	})
+}
+
+function validateAriaProperties(accessibilityRequirements) {
+	const aria12Key = Object.keys(accessibilityRequirements).find(key => key.startsWith('aria12:'))
+
+	if (aria12Key) {
+		// Check that aria key has an anchor name
+		expect(aria12Key.split(':')[1]).toBeTruthy()
+
+		// Check that aria object has the required properties
+		const requiredAriaProps = ['title', 'forConformance', 'failed', 'passed']
+		test.each(requiredAriaProps)('has required property `%s`', requiredProp => {
+			expect(accessibilityRequirements[aria12Key]).toHaveProperty(requiredProp)
+		})
+	}
 }

--- a/__tests__/frontmatter.js
+++ b/__tests__/frontmatter.js
@@ -1,7 +1,7 @@
 const describeRule = require('../test-utils/describe-rule')
 const describePage = require('../test-utils/describe-page')
 
-describe('frontmatter', () => {
+describe.only('frontmatter', () => {
 	/**
 	 * Rules
 	 */
@@ -90,22 +90,25 @@ function validateRuleFrontmatter({ frontmatter }, metaData) {
 	 * Check if `accessibility_requirements` (if any) has expected values
 	 */
 	if (accessibility_requirements) {
-		validateAriaProperties(accessibility_requirements)
 		/**
 		 * The below check the `values` for every `key - value` pair of accessibility requirements
 		 */
-		const accRequirementValues = Object.values(accessibility_requirements)
-		test.each(accRequirementValues)('has expected keys for accessibility requirement: `%p`', accReq => {
-			expect(accReq).not.toBeNull()
-			expect(typeof accReq).toBe('object')
-			const keys = Object.keys(accReq).sort()
+		const accessibilityReqs = Object.entries(accessibility_requirements).map(([key, value]) => ({ key, value }))
+		test.each(accessibilityReqs)('has expected keys for accessibility requirement: `%p`', ({ key, value }) => {
+			expect(value).not.toBeNull()
+			expect(typeof value).toBe('object')
+			const keys = Object.keys(value).sort()
 
 			if (keys.includes('secondary')) {
 				expect(keys.length).toBe(1)
-				expect(typeof accReq.secondary).toBe('string')
+				expect(typeof value.secondary).toBe('string')
 			} else {
+				const requiredProps = ['failed', 'forConformance', 'inapplicable', 'passed']
+				if (!/wcag-technique:.*/.test(key) && !/wcag2\d:.*/.test(key)) {
+					requiredProps.push('title')
+				}
 				expect(keys.length).toBeGreaterThanOrEqual(4)
-				expect(keys).toIncludeAllMembers(['failed', 'forConformance', 'inapplicable', 'passed'])
+				expect(keys).toIncludeAllMembers(requiredProps)
 			}
 		})
 	}
@@ -123,19 +126,4 @@ function validateGlossaryFrontmatter({ frontmatter }) {
 	test.each(requiredProps)('has required property `%s`', requiredProp => {
 		expect(frontmatter).toHaveProperty(requiredProp)
 	})
-}
-
-function validateAriaProperties(accessibilityRequirements) {
-	const aria12Key = Object.keys(accessibilityRequirements).find(key => key.startsWith('aria12:'))
-
-	if (aria12Key) {
-		// Check that aria key has an anchor name
-		expect(aria12Key.split(':')[1]).toBeTruthy()
-
-		// Check that aria object has the required properties
-		const requiredAriaProps = ['title', 'forConformance', 'failed', 'passed', 'inapplicable']
-		test.each(requiredAriaProps)('has required property `%s`', requiredProp => {
-			expect(accessibilityRequirements[aria12Key]).toHaveProperty(requiredProp)
-		})
-	}
 }

--- a/_rules/role-required-states-and-properties-4e8ab6.md
+++ b/_rules/role-required-states-and-properties-4e8ab6.md
@@ -11,7 +11,7 @@ accessibility_requirements:
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
-  aria12:requiredState: # 5.2.2 Required States and Properties
+  aria12:requiredState:
     title: ARIA 1.2, 5.2.2 Required States and Properties
     forConformance: true
     failed: not satisfied

--- a/_rules/role-required-states-and-properties-4e8ab6.md
+++ b/_rules/role-required-states-and-properties-4e8ab6.md
@@ -11,7 +11,7 @@ accessibility_requirements:
     failed: not satisfied
     passed: further testing needed
     inapplicable: further testing needed
-  aria12:requiredState:
+  aria12:requiredState: # 5.2.2 Required States and Properties
     forConformance: true
     failed: not satisfied
     passed: satisfied

--- a/_rules/role-required-states-and-properties-4e8ab6.md
+++ b/_rules/role-required-states-and-properties-4e8ab6.md
@@ -12,7 +12,6 @@ accessibility_requirements:
     passed: further testing needed
     inapplicable: further testing needed
   aria12:requiredState:
-    title: ARIA 1.2, 5.2.2 Required States and Properties
     forConformance: true
     failed: not satisfied
     passed: satisfied

--- a/_rules/role-required-states-and-properties-4e8ab6.md
+++ b/_rules/role-required-states-and-properties-4e8ab6.md
@@ -12,6 +12,7 @@ accessibility_requirements:
     passed: further testing needed
     inapplicable: further testing needed
   aria12:requiredState: # 5.2.2 Required States and Properties
+    title: ARIA 1.2, 5.2.2 Required States and Properties
     forConformance: true
     failed: not satisfied
     passed: satisfied


### PR DESCRIPTION
Adds a test for validating aria12 properties under `accessibility_requirements`. Since we expect a particular `accessibility_requirements` structure for the rules, the `frontmatter` tests act similar to typescript but for the frontmatter structure.

References this issue: https://github.com/act-rules/act-rules.github.io/pull/2328
The test job was failing before the fix: https://github.com/act-rules/act-rules.github.io/actions/runs/14984632459/job/42096095113

Need for Call for Review:
This will not require a Call for Review: adds a test

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
