### PR TITLE
Update programmatically-determined-link-context.md

### DIFF
--- a/pages/glossary/programmatically-determined-link-context.md
+++ b/pages/glossary/programmatically-determined-link-context.md
@@ -8,7 +8,7 @@ input_aspects:
   - DOM tree
 ---
 
-The _programmatically determined context_ of a link (or _programmatically determined link context_) is the link's [accessible description](https://www.w3.org/TR/accname/#dfn-accessible-description), combined with the set of all elements that are [included in the accessibility tree][], and have one or more of the following relationships to the link:
+The _programmatically determined context_ of a link (or _programmatically determined link context_) is the link's [accessible description][], combined with the set of all elements that are [included in the accessibility tree][], and have one or more of the following relationships to the link:
 
 - being an [ancestor][] of the link in the [flat tree][] with a [semantic role][] of `listitem`; or
 - being the closest [ancestor][] of the link in the [flat tree][] that generates a [block container][]; or

--- a/pages/glossary/programmatically-determined-link-context.md
+++ b/pages/glossary/programmatically-determined-link-context.md
@@ -8,7 +8,7 @@ input_aspects:
   - DOM tree
 ---
 
-The _programmatically determined context_ of a link (or _programmatically determined link context_) is the link's accessible description, combined with the set of all elements that are [included in the accessibility tree][], and have one or more of the following relationships to the link:
+The _programmatically determined context_ of a link (or _programmatically determined link context_) is the link's [accessible description](https://www.w3.org/TR/accname/#dfn-accessible-description), combined with the set of all elements that are [included in the accessibility tree][], and have one or more of the following relationships to the link:
 
 - being an [ancestor][] of the link in the [flat tree][] with a [semantic role][] of `listitem`; or
 - being the closest [ancestor][] of the link in the [flat tree][] that generates a [block container][]; or
@@ -25,3 +25,4 @@ This definition assumes that the HTML document with the link is a document using
 [flat tree]: https://drafts.csswg.org/css-scoping/#flat-tree 'CSS Scoping Module Level 1, flat tree, 2021/11/29'
 [included in the accessibility tree]: #included-in-the-accessibility-tree 'Definition of included in the accessibility tree'
 [semantic role]: #semantic-role 'Definition of semantic role'
+[accessible description]: https://www.w3.org/TR/accname/#dfn-accessible-description 

--- a/pages/glossary/programmatically-determined-link-context.md
+++ b/pages/glossary/programmatically-determined-link-context.md
@@ -8,7 +8,7 @@ input_aspects:
   - DOM tree
 ---
 
-The _programmatically determined context_ of a link (or _programmatically determined link context_) is the link's [accessible description][], combined with the set of all elements that are [included in the accessibility tree][], and have one or more of the following relationships to the link:
+The _programmatically determined context_ of a link (or _programmatically determined link context_) is the link's [accessible name][], [accessible description][], combined with the set of all elements that are [included in the accessibility tree][], and have one or more of the following relationships to the link:
 
 - being an [ancestor][] of the link in the [flat tree][] with a [semantic role][] of `listitem`; or
 - being the closest [ancestor][] of the link in the [flat tree][] that generates a [block container][]; or

--- a/pages/glossary/programmatically-determined-link-context.md
+++ b/pages/glossary/programmatically-determined-link-context.md
@@ -26,3 +26,4 @@ This definition assumes that the HTML document with the link is a document using
 [included in the accessibility tree]: #included-in-the-accessibility-tree 'Definition of included in the accessibility tree'
 [semantic role]: #semantic-role 'Definition of semantic role'
 [accessible description]: https://www.w3.org/TR/accname/#dfn-accessible-description 
+[accessible name]: https://www.w3.org/TR/accname/#dfn-accessible-name

--- a/pages/glossary/programmatically-determined-link-context.md
+++ b/pages/glossary/programmatically-determined-link-context.md
@@ -8,13 +8,12 @@ input_aspects:
   - DOM tree
 ---
 
-The _programmatically determined context_ of a link (or _programmatically determined link context_) is the set of all elements that are [included in the accessibility tree][], and have one or more of the following relationships to the link:
+The _programmatically determined context_ of a link (or _programmatically determined link context_) is the link's accessible description, combined with the set of all elements that are [included in the accessibility tree][], and have one or more of the following relationships to the link:
 
 - being an [ancestor][] of the link in the [flat tree][] with a [semantic role][] of `listitem`; or
 - being the closest [ancestor][] of the link in the [flat tree][] that generates a [block container][]; or
 - being the closest [ancestor][] of the link in the [flat tree][] that has a [semantic role][] of `cell` or `gridcell`; or
-- being a header cell [assigned][] to the closest [ancestor][] of the link in the [flat tree][] that has a [semantic role][] of `cell` or `gridcell`; or
-- being referenced by an `aria-describedby` attribute of the link.
+- being a header cell [assigned][] to the closest [ancestor][] of the link in the [flat tree][] that has a [semantic role][] of `cell` or `gridcell`.
 
 This definition is based on (but not equivalent to) the [WCAG definition of programmatically determined link context](https://www.w3.org/TR/WCAG22/#dfn-programmatically-determined-link-context).
 


### PR DESCRIPTION
Updated the glossary section to remove 'aria-decribedby' and changed the description from 'set of all elements' to 'link's accessible description, combined with the set of all elements'

<< Describe the changes >>

Closes issue(s):

- closes #1766 

Need for Call for Review:
This will not require a Call for Review << choose reason(s): editorial changes (including to the applicability, expectation or examples section), changes to assumptions, background, accessibility support, change to website/test code (not rule), other (explain). >>

---

### **After creating PR:**

- [ ] [Link the PR to any issue it solves](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue). This will be done automatically by [referencing the issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) at the top of this comment in the indicated place.
- [ ] Optionally request feedback from anyone in particular by assigning them as "Reviewers".

### **When merging a PR:**

- [ ] Close any issue that the PR resolves. This will happen automatically upon merging if the PR was correctly linked to the issue, e.g. by referencing the issue at the top of this comment.
