### PR TITLE
Deprecate ARIA required ID references exist (in6db8)

### DIFF
--- a/_rules/aria-required-id-references-in6db8.md
+++ b/_rules/aria-required-id-references-in6db8.md
@@ -22,6 +22,8 @@ input_aspects:
 acknowledgments:
   authors:
     - Wilco Fiers
+deprecated: |
+  This rule has been deprecated because the `aria-controls` attribute is no longer required by the combobox and scrollbar roles. This rule is not maintained anymore and should not be used.
 ---
 
 ## Applicability


### PR DESCRIPTION
Deprecating the rule because the `aria-controls` attribute is no longer required by the combobox and scrollbar roles. 
Decided by the CG in the [August 21 meeting](https://www.w3.org/2025/08/21-act-r-minutes.html).

Closes issue(s):

- closes #2337 

Need for Call for Review:
This will require a 2 weeks Call for Review << new rule, or substantial changes affecting a large number of test cases, if in doubt, use this.

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
