### PR TITLE
Update PR template to mention procedure for Accessibility Support notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,6 +27,7 @@ This will require a 2 weeks Call for Review << new rule, or substantial changes 
 - [ ] Add label to indicate if it's a `Rule`, `Definition` or `Chore`.
 - [ ] [Link the PR to any issue it solves](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue). This will be done automatically by [referencing the issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) at the top of this comment in the indicated place.
 - [ ] Optionally request feedback from anyone in particular by assigning them as "Reviewers".
+- [ ] If your PR is for a new rule with an Accessibility Support note, or for updating the Accessibility Support note of an existing section, make sure to open a corresponding Accessibility Support issue.
 
 ### **When merging a PR:**
 


### PR DESCRIPTION
Added a checklist item for Accessibility Support notes in PR template.

Need for Call for Review:

- This can be merged with 1 approval << choose reason: editorial changes to website/test code, adding new contributor, other (explain). >>

---

## Pull Request Etiquette

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
