### PR TITLE
aria-required-owned-element should not allow invalid children for having aria-busy

### DIFF
--- a/_rules/aria-required-owned-element-bc4a75.md
+++ b/_rules/aria-required-owned-element-bc4a75.md
@@ -27,7 +27,7 @@ acknowledgments:
 
 ## Applicability
 
-This rule applies to any [HTML or SVG element][] that is [included in the accessibility tree][] and has a [WAI-ARIA 1.2][] [semantic role][] with [required owned elements][], except if the element has an [inclusive ancestor][] in the accessibility tree with an `aria-busy` [attribute value][] of `true`.
+This rule applies to any [HTML or SVG element][] that is [included in the accessibility tree][] and has a [WAI-ARIA 1.2][] [semantic role][] with [required owned elements][].
 
 ## Expectation
 
@@ -45,7 +45,9 @@ The applicability of this rule is limited to the [WAI-ARIA 1.2 Recommendation][w
 
 ### Assumptions
 
-If the [semantic role][] on the target element is incorrectly used, and any relationships between elements are already programmatically determinable, failing this rule may not result in accessibility issues for users of assistive technologies, and it should then not be considered a failure under [WCAG success criterion 1.3.1 Info and Relationships](https://www.w3.org/TR/WCAG22/#info-and-relationships).
+- If the [semantic role][] on the target element is incorrectly used, and any relationships between elements are already programmatically determinable, failing this rule may not result in accessibility issues for users of assistive technologies, and it should then not be considered a failure under [WCAG success criterion 1.3.1 Info and Relationships](https://www.w3.org/TR/WCAG22/#info-and-relationships).
+
+- Adding `aria-busy` to an element does not create an exception to this rule. The purpose of `aria-busy` is to communicate that a live region is in the process of updating, so that screen readers can hold off an announcing a change until the update is completed. It is not intended to communicating a loading state, or allow placing loading messages inside elements that aren't fully rendered.
 
 ### Accessibility Support
 
@@ -312,6 +314,16 @@ This element with the implicit `list` role owns an element with the implicit `ge
 </ul>
 ```
 
+#### Failed Example 11
+
+Even though element with the `menu` role has an `aria-busy` attribute set to `true`, that does not permit using other roles as children.
+
+```html
+<ul role="menu" aria-busy="true">
+	Loading
+</ul>
+```
+
 ### Inapplicable
 
 #### Inapplicable Example 1
@@ -338,16 +350,6 @@ This element with the `progressbar` role does not need [required owned elements]
 
 ```html
 <div role="progressbar" aria-valuenow="20" aria-valuemin="0" aria-valuemax="100" aria-label="Completion">20 %</div>
-```
-
-#### Inapplicable Example 4
-
-This element with the `menu` role has an `aria-busy` attribute set to `true`.
-
-```html
-<ul role="menu" aria-busy="true">
-	Loading
-</ul>
 ```
 
 [attribute value]: #attribute-value 'Definition of Attribute Value'


### PR DESCRIPTION
I've been looking over `aria-busy`, and I think we've been too permissive with it. Nowhere does ARIA actually say that if you put `aria-busy` on element that it can contain non-allowed children. What ARIA 1.2 said is that if an element is empty because content wasn't loaded yet authors must set aria-busy. This was has been pulled from ARIA 1.3 though, along with the rest of the required children section, because ARIA 1.3 now has allowed child roles. It doesn't mention aria-busy at all.

I think that allowing an `aria-busy` exception was a mistake, and that this "loading" example we have is invalid. `aria-busy` isn't intended to communicate a loading state. All it does is tell screen readers to wait in pronouncing live region changes because they aren't done. See also https://github.com/w3c/aria/issues/2424

Need for Call for Review: 2 weeks, this breaks basically every automated implementation.

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
