### PR TITLE
Update rules mapping for SC 3.1.1 Language of Page to address empty content [bf051a, ucwvc8, b5c3f8]

### DIFF
--- a/_rules/html-page-lang-b5c3f8.md
+++ b/_rules/html-page-lang-b5c3f8.md
@@ -21,6 +21,7 @@ input_aspects:
 acknowledgments:
   authors:
     - Jey Nandakumar
+    - Giacomo Petri
   previous_authors:
     - Annika Nietzio
   funding:

--- a/_rules/html-page-lang-b5c3f8.md
+++ b/_rules/html-page-lang-b5c3f8.md
@@ -32,7 +32,8 @@ acknowledgments:
 This rule applies to any [document element](https://dom.spec.whatwg.org/#document-element) if it is an `html` element for which all the following are true:
 
 - is in a [top-level browsing context](https://html.spec.whatwg.org/#top-level-browsing-context); and
-- has a [node document](https://dom.spec.whatwg.org/#concept-node-document) with a [content type](https://dom.spec.whatwg.org/#concept-document-content-type) of `text/html`.
+- has a [node document](https://dom.spec.whatwg.org/#concept-node-document) with a [content type](https://dom.spec.whatwg.org/#concept-document-content-type) of `text/html`; and
+- has at least one [descendant](https://dom.spec.whatwg.org/#concept-tree-descendant) [text node][] which is neither empty nor only [whitespace][]..
 
 **Note:** `html` elements within `iframe` and `object` elements are not applicable as `iframe` and `object` elements create [nested browsing contexts](https://html.spec.whatwg.org/#nested-browsing-context). However, as these elements are meant to provide a layer of isolation, the declared language of their [parent browsing context](https://html.spec.whatwg.org/#parent-browsing-context) will likely not be inherited, making it possible for empty `lang` attributes in [nested browsing contexts](https://html.spec.whatwg.org/#nested-browsing-context) to also cause accessibility issues.
 
@@ -150,6 +151,16 @@ This rule does not apply to a `math` element.
 <math lang="en">
     The quick brown fox jumps over the lazy dog.
 </math>
+```
+
+#### Inapplicable Example 3
+
+This rule does not apply to content that is empty or contains only [whitespace][].
+
+```html
+<html>
+	<body></body>
+</html>
 ```
 
 [attribute value]: #attribute-value

--- a/_rules/html-page-lang-b5c3f8.md
+++ b/_rules/html-page-lang-b5c3f8.md
@@ -20,8 +20,8 @@ input_aspects:
   - DOM Tree
 acknowledgments:
   authors:
-    - Jey Nandakumar
     - Giacomo Petri
+    - Jey Nandakumar
   previous_authors:
     - Annika Nietzio
   funding:

--- a/_rules/html-page-lang-b5c3f8.md
+++ b/_rules/html-page-lang-b5c3f8.md
@@ -34,7 +34,10 @@ This rule applies to any [document element](https://dom.spec.whatwg.org/#documen
 
 - is in a [top-level browsing context](https://html.spec.whatwg.org/#top-level-browsing-context); and
 - has a [node document](https://dom.spec.whatwg.org/#concept-node-document) with a [content type](https://dom.spec.whatwg.org/#concept-document-content-type) of `text/html`; and
-- has at least one [descendant](https://dom.spec.whatwg.org/#concept-tree-descendant) [text node][] which is neither empty nor only [whitespace][]..
+- has at least one of the following [descendant](https://dom.spec.whatwg.org/#concept-tree-descendant) that is not empty or only [whitespace][]:
+	- [text node][] that is included in the accessibility tree; or
+ 	- an element's [accessible name][] or [accessible description](https://www.w3.org/TR/accname-1.1/#dfn-accessible-description) that is exposed in the accessibility tree; or
+  	- the document's title.
 
 **Note:** `html` elements within `iframe` and `object` elements are not applicable as `iframe` and `object` elements create [nested browsing contexts](https://html.spec.whatwg.org/#nested-browsing-context). However, as these elements are meant to provide a layer of isolation, the declared language of their [parent browsing context](https://html.spec.whatwg.org/#parent-browsing-context) will likely not be inherited, making it possible for empty `lang` attributes in [nested browsing contexts](https://html.spec.whatwg.org/#nested-browsing-context) to also cause accessibility issues.
 

--- a/_rules/html-page-lang-matches-default-ucwvc8.md
+++ b/_rules/html-page-lang-matches-default-ucwvc8.md
@@ -23,8 +23,8 @@ input_aspects:
   - Language
 acknowledgments:
   authors:
-    - Wilco Fiers
     - Giacomo Petri
+    - Wilco Fiers
   funding:
     - WAI-Tools
 htmlHintIgnore:

--- a/_rules/html-page-lang-matches-default-ucwvc8.md
+++ b/_rules/html-page-lang-matches-default-ucwvc8.md
@@ -24,6 +24,7 @@ input_aspects:
 acknowledgments:
   authors:
     - Wilco Fiers
+    - Giacomo Petri
   funding:
     - WAI-Tools
 htmlHintIgnore:

--- a/_rules/html-page-lang-matches-default-ucwvc8.md
+++ b/_rules/html-page-lang-matches-default-ucwvc8.md
@@ -41,7 +41,10 @@ This rule applies to any [document element][] if it is an `html` element for whi
 - The [document element][] is in a [top-level browsing context][]; and
 - The [document element][] has a [content type][] of `text/html`; and
 - The [document element][] has a defined [default page language][]; and
-- The [document element][] has at least one [descendant](https://dom.spec.whatwg.org/#concept-tree-descendant) [text node][] which is neither empty nor only [whitespace][].
+- The [document element][] has at least one of the following [descendant](https://dom.spec.whatwg.org/#concept-tree-descendant) that is not empty or only [whitespace][]:
+	- [text node][] that is included in the accessibility tree; or
+ 	- an element's [accessible name][] or [accessible description](https://www.w3.org/TR/accname-1.1/#dfn-accessible-description) that is exposed in the accessibility tree; or
+  	- the document's title.
 
 ## Expectation
 

--- a/_rules/html-page-lang-matches-default-ucwvc8.md
+++ b/_rules/html-page-lang-matches-default-ucwvc8.md
@@ -39,7 +39,8 @@ This rule applies to any [document element][] if it is an `html` element for whi
 - The [document element][] has a `lang` attribute with a value that has a [known primary language tag][]; and
 - The [document element][] is in a [top-level browsing context][]; and
 - The [document element][] has a [content type][] of `text/html`; and
-- The [document element][] has a defined [default page language][].
+- The [document element][] has a defined [default page language][]; and
+- The [document element][] has at least one [descendant](https://dom.spec.whatwg.org/#concept-tree-descendant) [text node][] which is neither empty nor only [whitespace][].
 
 ## Expectation
 
@@ -319,6 +320,16 @@ The `lang` [attribute value][] of this page is a [grandfathered tag][grandfather
 	<body>
 		<p lang="lb">Lëtzebuerg ass e Land an Europa.</p>
 	</body>
+</html>
+```
+
+#### Inapplicable Example 7
+
+This rule does not apply to content that is empty or contains only [whitespace][].
+
+```html
+<html lang="em-US">
+	<body></body>
 </html>
 ```
 

--- a/_rules/html-page-lang-valid-bf051a.md
+++ b/_rules/html-page-lang-valid-bf051a.md
@@ -20,8 +20,8 @@ input_aspects:
   - DOM Tree
 acknowledgments:
   authors:
-    - Jey Nandakumar
     - Giacomo Petri
+    - Jey Nandakumar
   previous_authors:
     - Annika Nietzio
   funding:

--- a/_rules/html-page-lang-valid-bf051a.md
+++ b/_rules/html-page-lang-valid-bf051a.md
@@ -21,6 +21,7 @@ input_aspects:
 acknowledgments:
   authors:
     - Jey Nandakumar
+    - Giacomo Petri
   previous_authors:
     - Annika Nietzio
   funding:
@@ -33,7 +34,8 @@ This rule applies to any [document element](https://dom.spec.whatwg.org/#documen
 
 - has a `lang` attribute that is neither empty ("") nor only [ASCII whitespace](https://infra.spec.whatwg.org/#ascii-whitespace); and
 - is in a [top-level browsing context](https://html.spec.whatwg.org/#top-level-browsing-context); and
-- has a [node document](https://dom.spec.whatwg.org/#concept-node-document) with a [content type](https://dom.spec.whatwg.org/#concept-document-content-type) of `text/html`.
+- has a [node document](https://dom.spec.whatwg.org/#concept-node-document) with a [content type](https://dom.spec.whatwg.org/#concept-document-content-type) of `text/html`; and
+- has at least one [descendant](https://dom.spec.whatwg.org/#concept-tree-descendant) [text node][] which is neither empty nor only [whitespace][].
 
 ## Expectation
 
@@ -73,18 +75,39 @@ This rule is only applicable to non-embedded HTML pages. HTML pages embedded int
 
 #### Passed Example 1
 
-This `html` element has a `lang` attribute with a [known primary language tag][].
+This `html` element has a `lang` attribute with a [known primary language tag][] and non-empty `body` content.
 
 ```html
-<html lang="FR"></html>
+<html lang="it">
+	<body>
+		<p>Amo le regole ACT!</p>
+	</body>
+</html>
 ```
 
 #### Passed Example 2
 
+This `html` element has a `lang` attribute with a [known primary language tag][] and non-empty `title`.
+
+```html
+<html lang="it">
+	<head>
+		<title>Amo le regole ACT!</title>
+	</head>
+	<body></body>
+</html>
+```
+
+#### Passed Example 3
+
 This `html` element has a `lang` attribute with a [known primary language tag][] even though the [region subtag][] is not.
 
 ```html
-<html lang="en-US-GB"></html>
+<html lang="en-US-GB">
+	<body>
+		<p lang="en">I love ACT rules!</p>
+	</body>
+</html>
 ```
 
 ### Failed
@@ -94,7 +117,11 @@ This `html` element has a `lang` attribute with a [known primary language tag][]
 This `html` element has a `lang` attribute, with no [known primary language tag][].
 
 ```html
-<html lang="em-US"></html>
+<html lang="em-US">
+	<body>
+		<p lang="en">I love ACT rules!</p>
+	</body>
+</html>
 ```
 
 #### Failed Example 2
@@ -102,7 +129,11 @@ This `html` element has a `lang` attribute, with no [known primary language tag]
 This `html` element has a `lang` attribute, with no [known primary language tag][].
 
 ```html
-<html lang="#1"></html>
+<html lang="#1">
+	<body>
+		<p lang="en">I love ACT rules!</p>
+	</body>
+</html>
 ```
 
 #### Failed Example 3
@@ -137,6 +168,16 @@ This rule does not apply to `svg` elements.
 
 ```svg
 <svg xmlns="http://www.w3.org/2000/svg" lang="fr"></svg>
+```
+
+#### Inapplicable Example 2
+
+This rule does not apply to content that is empty or contains only [whitespace][].
+
+```html
+<html lang="em-US">
+	<body></body>
+</html>
 ```
 
 [grandfathered tags]: https://www.rfc-editor.org/rfc/rfc5646.html#section-2.2.8

--- a/_rules/html-page-lang-valid-bf051a.md
+++ b/_rules/html-page-lang-valid-bf051a.md
@@ -35,7 +35,10 @@ This rule applies to any [document element](https://dom.spec.whatwg.org/#documen
 - has a `lang` attribute that is neither empty ("") nor only [ASCII whitespace](https://infra.spec.whatwg.org/#ascii-whitespace); and
 - is in a [top-level browsing context](https://html.spec.whatwg.org/#top-level-browsing-context); and
 - has a [node document](https://dom.spec.whatwg.org/#concept-node-document) with a [content type](https://dom.spec.whatwg.org/#concept-document-content-type) of `text/html`; and
-- has at least one [descendant](https://dom.spec.whatwg.org/#concept-tree-descendant) [text node][] which is neither empty nor only [whitespace][].
+- has at least one of the following [descendant](https://dom.spec.whatwg.org/#concept-tree-descendant) that is not empty or only [whitespace][]:
+	- [text node][] that is included in the accessibility tree; or
+ 	- an element's [accessible name][] or [accessible description](https://www.w3.org/TR/accname-1.1/#dfn-accessible-description) that is exposed in the accessibility tree; or
+  	- the document's title.
 
 ## Expectation
 


### PR DESCRIPTION
Closes issue(s): #2406

This PR introduces a new exception to the rules mapping for SC 3.1.1 Language of Page, ensuring that pages with no content are treated as an exception, since there is no lang to communicate to the user.

Need for Call for Review:
This will require a 2 weeks Call for Review 

---

## How to Review And Approve

- Go to the “Files changed” tab
- Here you will have the option to leave comments on different lines.
- Once the review is completed, find the “Review changes” button in the top right, select “Approve” (if you are really confident in the rule) or "Request changes" and click “Submit review”.
- Make sure to also review the proposed Call for Review period. In case of disagreement, the longer period wins.
